### PR TITLE
 NXS-5943: Updated all the projects in the SDK to use .NET 8.0 #27

### DIFF
--- a/Nexus.Sdk.Shared.Tests/Nexus.Sdk.Shared.Tests.csproj
+++ b/Nexus.Sdk.Shared.Tests/Nexus.Sdk.Shared.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/Nexus.Sdk.Shared/Nexus.Sdk.Shared.csproj
+++ b/Nexus.Sdk.Shared/Nexus.Sdk.Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<PackageProjectUrl>https://github.com/QuantozTechnology/Nexus.Sdk.Dotnet/Nexus.Sdk.Shared</PackageProjectUrl>

--- a/Nexus.Sdk.Token.Tests/Nexus.Sdk.Token.Tests.csproj
+++ b/Nexus.Sdk.Token.Tests/Nexus.Sdk.Token.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/Nexus.Sdk.Token/Nexus.Sdk.Token.csproj
+++ b/Nexus.Sdk.Token/Nexus.Sdk.Token.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<PackageProjectUrl>https://github.com/QuantozTechnology/Nexus.Sdk.Dotnet/Nexus.Sdk.Token</PackageProjectUrl>

--- a/Nexus.Token.Algorand.Examples/Nexus.Token.Algorand.Examples.csproj
+++ b/Nexus.Token.Algorand.Examples/Nexus.Token.Algorand.Examples.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<UserSecretsId>1fd3e177-39e7-4196-8213-81d984178923</UserSecretsId>

--- a/Nexus.Token.Stellar.Examples/Nexus.Token.Stellar.Examples.csproj
+++ b/Nexus.Token.Stellar.Examples/Nexus.Token.Stellar.Examples.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UserSecretsId>b12a33fa-9ffa-4b40-bd02-0e4a497f6675</UserSecretsId>


### PR DESCRIPTION
Problem
.NET 7.0 is now outdated and won't be supported any longer

Solution
Update the .NET version to the newest 8.0