### PR TITLE
NXS-5943: Updated all packages (because .net version got updated to 8.0)

### DIFF
--- a/Nexus.Sdk.Shared.Tests/Nexus.Sdk.Shared.Tests.csproj
+++ b/Nexus.Sdk.Shared.Tests/Nexus.Sdk.Shared.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
@@ -9,12 +9,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Moq" Version="4.18.2" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
-    <PackageReference Include="coverlet.collector" Version="3.1.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="NUnit" Version="4.1.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.2.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Nexus.Sdk.Shared/Nexus.Sdk.Shared.csproj
+++ b/Nexus.Sdk.Shared/Nexus.Sdk.Shared.csproj
@@ -17,10 +17,10 @@
 	</PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IdentityModel" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
-    <PackageReference Include="ReHackt.Extensions.Options.Validation" Version="7.0.0" />
+    <PackageReference Include="IdentityModel" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+	<PackageReference Include="ReHackt.Extensions.Options.Validation" Version="8.0.2" />
   </ItemGroup>
 
 </Project>

--- a/Nexus.Sdk.Token.Tests/Nexus.Sdk.Token.Tests.csproj
+++ b/Nexus.Sdk.Token.Tests/Nexus.Sdk.Token.Tests.csproj
@@ -9,11 +9,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
-    <PackageReference Include="coverlet.collector" Version="3.1.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="NUnit" Version="4.1.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.2.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Nexus.Sdk.Token/Nexus.Sdk.Token.csproj
+++ b/Nexus.Sdk.Token/Nexus.Sdk.Token.csproj
@@ -17,8 +17,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Algorand" Version="0.2.1" />
-		<PackageReference Include="ReHackt.Extensions.Options.Validation" Version="7.0.0" />
-		<PackageReference Include="stellar-dotnet-sdk" Version="8.0.6" />
+		<PackageReference Include="ReHackt.Extensions.Options.Validation" Version="8.0.2" />
+		<PackageReference Include="stellar-dotnet-sdk" Version="9.1.3" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Nexus.Token.Algorand.Examples/Nexus.Token.Algorand.Examples.csproj
+++ b/Nexus.Token.Algorand.Examples/Nexus.Token.Algorand.Examples.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
@@ -9,9 +9,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="NJsonSchema" Version="10.7.2" />
-		<PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
-		<PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
+		<PackageReference Include="NJsonSchema" Version="11.0.0" />
+		<PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
+		<PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Nexus.Token.Algorand.Examples/appsettings.json
+++ b/Nexus.Token.Algorand.Examples/appsettings.json
@@ -1,14 +1,14 @@
 {
   "NexusOptions": {
-    "ApiUrl": "https://devapi.quantoz.com",
+    "ApiUrl": "https://testapi.quantoz.com",
     "PaymentMethodOptions": {
       "Funding": "",
       "Payout": ""
     },
     "AuthProviderOptions": {
-      "IdentityUrl": "https://devidentity.quantoz.com",
-      "ClientId": "NcSHavRaIyksaRYTsIVXNYYYINyaEwyA",
-      "ClientSecret": "secret"
+      "IdentityUrl": "https://testidentity.quantoz.com",
+      "ClientId": "",
+      "ClientSecret": ""
     }
   }
 }

--- a/Nexus.Token.Algorand.Examples/appsettings.json
+++ b/Nexus.Token.Algorand.Examples/appsettings.json
@@ -1,14 +1,14 @@
 {
   "NexusOptions": {
-    "ApiUrl": "https://testapi.quantoz.com",
+    "ApiUrl": "https://devapi.quantoz.com",
     "PaymentMethodOptions": {
       "Funding": "",
       "Payout": ""
     },
     "AuthProviderOptions": {
-      "IdentityUrl": "https://testidentity.quantoz.com",
-      "ClientId": "",
-      "ClientSecret": ""
+      "IdentityUrl": "https://devidentity.quantoz.com",
+      "ClientId": "NcSHavRaIyksaRYTsIVXNYYYINyaEwyA",
+      "ClientSecret": "secret"
     }
   }
 }

--- a/Nexus.Token.Stellar.Examples/Nexus.Token.Stellar.Examples.csproj
+++ b/Nexus.Token.Stellar.Examples/Nexus.Token.Stellar.Examples.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="NJsonSchema" Version="10.7.2" />
-	  <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
-	  <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
+	  <PackageReference Include="NJsonSchema" Version="11.0.0" />
+	  <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
+	  <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Problem
.NET 7.0 is now outdated and won't be supported any longer, all packages must be updated

Solution
Update the .NET version to the newest 8.0 and updated all the packages