### PR TITLE
Add AccountType to AccountResponse

### DIFF
--- a/Nexus.Sdk.Token/Responses/AccountResponses.cs
+++ b/Nexus.Sdk.Token/Responses/AccountResponses.cs
@@ -5,13 +5,14 @@ namespace Nexus.Sdk.Token.Responses;
 public record AccountResponse
 {
     [JsonConstructor]
-    public AccountResponse(string customerCode, string accountCode, string cryptoCode, string publicKey, string status)
+    public AccountResponse(string customerCode, string accountCode, string cryptoCode, string publicKey, string status, string accountType)
     {
         CustomerCode = customerCode;
         AccountCode = accountCode;
         CryptoCode = cryptoCode;
         PublicKey = publicKey;
         Status = status;
+        AccountType = accountType;
     }
 
     [JsonPropertyName("customerCode")]
@@ -28,6 +29,9 @@ public record AccountResponse
 
     [JsonPropertyName("accountStatus")]
     public string Status { get; set; }
+
+    [JsonPropertyName("accountType")]
+    public string AccountType { get; set; }
 }
 
 public record UpdateTokenAccountResponse


### PR DESCRIPTION
**Description:**
To know the customer's account type (Self-managed vs Internal) for automatic payout handling of external accounts

**Added:**
AccountType to AccountResponse