### PR TITLE
For Business customer, use Name for businessName and not companyName

### DIFF
--- a/Nexus.Sdk.Shared.Tests/CustomerRequestBuilderTests.cs
+++ b/Nexus.Sdk.Shared.Tests/CustomerRequestBuilderTests.cs
@@ -321,7 +321,7 @@ namespace Nexus.Sdk.Shared.Tests
         }
 
         [Test]
-        public void CustomerRequestBuilderTests_Build_CompanyName()
+        public void CustomerRequestBuilderTests_Build_BusinessName()
         {
             var request = new CreateCustomerRequestBuilder(
                 "MOCK_CUSTOMER", "Trusted", "EUR")
@@ -329,7 +329,7 @@ namespace Nexus.Sdk.Shared.Tests
                 .SetEmail("test@test.com")
                 .SetCountry("NL")
                 .SetStatus(CustomerStatus.ACTIVE)
-                .SetCompanyName("XYZ")
+                .SetName("XYZ")
                 .Build();
 
             Assert.Multiple(() =>
@@ -341,7 +341,7 @@ namespace Nexus.Sdk.Shared.Tests
                 Assert.That(request.Status, Is.EqualTo("ACTIVE"));
                 Assert.That(request.CurrencyCode, Is.EqualTo("EUR"));
                 Assert.That(request.CountryCode, Is.EqualTo(expected: "NL"));
-                Assert.That(request.CompanyName, Is.EqualTo("XYZ"));
+                Assert.That(request.Name, Is.EqualTo("XYZ"));
                 Assert.That(request.IsBusiness, Is.True);
                 Assert.That(request.BankAccounts, Is.Null);
                 Assert.That(request.Data, Is.Null);

--- a/Nexus.Sdk.Shared/Responses/CustomerDataResponse.cs
+++ b/Nexus.Sdk.Shared/Responses/CustomerDataResponse.cs
@@ -5,9 +5,10 @@ namespace Nexus.Sdk.Shared.Responses
     public class CustomerDataResponse
     {
         [JsonConstructor]
-        public CustomerDataResponse(string customerCode, string firstName, string lastName, string dateOfBirth, string countryName, string address, string city, string state, string phone, string companyName)
+        public CustomerDataResponse(string customerCode, string name, string firstName, string lastName, string dateOfBirth, string countryName, string address, string city, string state, string phone, string companyName)
         {
             CustomerCode = customerCode;
+            Name = name;
             FirstName = firstName;
             LastName = lastName;
             DateOfBirth = dateOfBirth;
@@ -21,6 +22,9 @@ namespace Nexus.Sdk.Shared.Responses
 
         [JsonPropertyName("customerCode")]
         public string CustomerCode { get; private set; }
+
+        [JsonPropertyName("name")]
+        public string? Name { get; private set; }
 
         [JsonPropertyName("firstName")]
         public string? FirstName { get; private set; }

--- a/Nexus.Sdk.Shared/Responses/CustomerResponses.cs
+++ b/Nexus.Sdk.Shared/Responses/CustomerResponses.cs
@@ -5,10 +5,11 @@ namespace Nexus.Sdk.Shared.Responses;
 public record CustomerResponse
 {
     [JsonConstructor]
-    public CustomerResponse(string customerCode, string firstName, string lastName, string dateOfBirth, string phone, string companyName, string trustLevel, 
+    public CustomerResponse(string customerCode,string? name, string firstName, string lastName, string dateOfBirth, string phone, string companyName, string trustLevel, 
         string currencyCode, string countryCode, string? email, string status, string bankAccount, bool isBusiness, string riskQualification, IDictionary<string, string> data)
     {
         CustomerCode = customerCode;
+        Name = name;
         FirstName = firstName;
         LastName = lastName;
         DateOfBirth = dateOfBirth;
@@ -27,6 +28,9 @@ public record CustomerResponse
 
     [JsonPropertyName("customerCode")]
     public string CustomerCode { get; set; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
 
     [JsonPropertyName("firstName")]
     public string? FirstName { get; set; }

--- a/Nexus.Sdk.Token.Tests/Helpers/MockTokenServerProvider.cs
+++ b/Nexus.Sdk.Token.Tests/Helpers/MockTokenServerProvider.cs
@@ -52,6 +52,7 @@ namespace Nexus.Sdk.Token.Tests.Helpers
 
             return Task.FromResult(new CustomerResponse(
                 request.CustomerCode!,
+                request.Name!,
                 request.FirstName!,
                 request.LastName!,
                 request.DateOfBirth!,


### PR DESCRIPTION
Hi,

For fundingChecks we have Name check for incoming fundings to make sure customer name (in Nexus) is similar to bank account name from which funding is sent.

Similar to private customers, for business customers, we need to compare it with Business Name, which in nexus api is as customer property `name` , in SDK that property is mapped and also test is changed from companyName to BusinessName as it is important incase of business customer. 