### PR TITLE
Add ReasonCode for UpdateCustomerRequest 

### DIFF
--- a/Nexus.Sdk.Shared.Tests/CustomerRequestBuilderTests.cs
+++ b/Nexus.Sdk.Shared.Tests/CustomerRequestBuilderTests.cs
@@ -443,6 +443,7 @@ namespace Nexus.Sdk.Shared.Tests
         {
             var request = new UpdateCustomerRequestBuilder("MOCK_CUSTOMER")
                 .SetTrustLevel("Trusted")
+                .SetReason("ReasonCode")
                 .SetReason("Reason")
                 .SetEmail("test@test.com")
                 .SetStatus(CustomerStatus.ACTIVE)

--- a/Nexus.Sdk.Shared.Tests/CustomerRequestBuilderTests.cs
+++ b/Nexus.Sdk.Shared.Tests/CustomerRequestBuilderTests.cs
@@ -443,7 +443,7 @@ namespace Nexus.Sdk.Shared.Tests
         {
             var request = new UpdateCustomerRequestBuilder("MOCK_CUSTOMER")
                 .SetTrustLevel("Trusted")
-                .SetReason("ReasonCode")
+                .SetReasonCode("ReasonCode")
                 .SetReason("Reason")
                 .SetEmail("test@test.com")
                 .SetStatus(CustomerStatus.ACTIVE)

--- a/Nexus.Sdk.Shared/Requests/CustomerRequest.cs
+++ b/Nexus.Sdk.Shared/Requests/CustomerRequest.cs
@@ -99,6 +99,10 @@ public class UpdateCustomerRequest : CustomerRequest
     [JsonPropertyName("trustLevelCode")]
     public string? TrustLevel { get; set; }
 
+    [JsonPropertyName("reasonCode")]
+    [StringLength(100)]
+    public string? ReasonCode { get; set; }
+
     [JsonPropertyName("reason")]
     [StringLength(1024)]
     public string? Reason { get; set; }

--- a/Nexus.Sdk.Shared/Requests/CustomerRequestBuilders.cs
+++ b/Nexus.Sdk.Shared/Requests/CustomerRequestBuilders.cs
@@ -181,6 +181,12 @@
             return this;
         }
 
+        public UpdateCustomerRequestBuilder SetReasonCode(string reasonCode)
+        {
+            _request.ReasonCode = reasonCode;
+            return this;
+        }
+
         public UpdateCustomerRequestBuilder SetReason(string reason)
         {
             _request.Reason = reason;


### PR DESCRIPTION
When we update a customer we can also provide `ReasonCode `in Nexus API, now SDK also has that property mapped and will be able to add `ReasonCode` when customer is Updated