### PR TITLE
NXS-6267 : Set default values for IsReviewed and IsPEP properties

### DIFF
--- a/Nexus.Sdk.Shared/Requests/CustomerRequest.cs
+++ b/Nexus.Sdk.Shared/Requests/CustomerRequest.cs
@@ -76,10 +76,10 @@ public class CustomerRequest
     public string? ExternalCustomerCode { get; set; }
 
     [JsonPropertyName("IsReviewed")]
-    public bool? IsReviewed { get; set; }
+    public bool? IsReviewed { get; set; } = false;
 
     [JsonPropertyName("isPEP")]
-    public bool? IsPEP { get; set; }
+    public bool? IsPEP { get; set; } = false;
 
     public IDictionary<string, string>? Data { get; set; }
 }


### PR DESCRIPTION
The IsReviewed and IsPEP properties in the CustomerRequest class now default to false. This change ensures that new instances of CustomerRequest have a clear initial state and helps prevent null reference issues.