### PR TITLE
NXS-6295: Update Nexus SDK with blockchain transaction ID

### DIFF
--- a/Nexus.Sdk.Token/Responses/TokenOperationResponse.cs
+++ b/Nexus.Sdk.Token/Responses/TokenOperationResponse.cs
@@ -5,7 +5,7 @@ namespace Nexus.Sdk.Token.Responses
     public record TokenOperationResponse
     {
         [JsonConstructor]
-        public TokenOperationResponse(string code, string hash, OperationAccountResponses senderAccount, OperationAccountResponses receiverAccount, decimal amount, string created, string? finished, string status, string type, string? memo, string? message, string cryptoCode, string tokenCode, string paymentReference, decimal? fiatAmount, decimal? netFiatAmount)
+        public TokenOperationResponse(string code, string hash, OperationAccountResponses senderAccount, OperationAccountResponses receiverAccount, decimal amount, string created, string? finished, string status, string type, string? memo, string? message, string cryptoCode, string tokenCode, string paymentReference, decimal? fiatAmount, decimal? netFiatAmount, string blockchainTransactionId)
         {
             Code = code;
             Hash = hash;
@@ -23,6 +23,7 @@ namespace Nexus.Sdk.Token.Responses
             PaymentReference = paymentReference;
             FiatAmount = fiatAmount;
             NetFiatAmount = netFiatAmount;
+            BlockchainTransactionId = blockchainTransactionId;
         }
 
         [JsonPropertyName("code")]
@@ -72,5 +73,8 @@ namespace Nexus.Sdk.Token.Responses
 
         [JsonPropertyName("netFiatAmount")]
         public decimal? NetFiatAmount { get; private set; }
+
+        [JsonPropertyName("blockchainTransactionId")]
+        public string BlockchainTransactionId { get; set; }
     }
 }


### PR DESCRIPTION
**Context**
In the [Nexus.Token repo](https://github.com/QuantozTechnology/Nexus.Token), the Token Operations API (GET /token/operations) allows clients to filter by the blockchain transaction id but the blockchain transaction id is not returned in the response. This response value is needed by at least one Label Partner: `QPay`

To address the above, the blockchain transaction id was added to the `TokenPayment` model returned by the following two endpoints:
-  GET /token/operations
-  GET /token/payments

See the following pull request for more info on the changes made to the Nexus.Token repo: https://github.com/QuantozTechnology/Nexus.Token/pull/9

**Issue**
Ensure the SDK repo remains compatible with the changes made to the Nexus.Token repo.

**Solution**
- [Added a new string field named blockchainTransactionId to the TokenOperationResponse](https://github.com/QuantozTechnology/Nexus.Sdk.Dotnet/blob/f832c271a15086ecf8ff30fd4206e0c110a1b910/Nexus.Sdk.Token/Responses/TokenOperationResponse.cs#L26)