### PR TITLE
NXS-6351: Add status for payout response

### DIFF
--- a/Nexus.Sdk.Token/Responses/PayoutResponse.cs
+++ b/Nexus.Sdk.Token/Responses/PayoutResponse.cs
@@ -30,6 +30,9 @@ namespace Nexus.Sdk.Token.Responses
 
         [JsonPropertyName("paymentCode")]
         public string? PaymentCode { get; set; }
+
+        [JsonPropertyName("status")]
+        public string? Status { get; set; }
     }
 
     public record ExecutedAmounts


### PR DESCRIPTION
Add property `status`  to `PayoutResponse` on Payout creation in Nexus. As this property is now available in Nexus API when a payout is created, it should return Payout Status also. 