### PR TITLE
NXS-6457 : Make References property required in CreateMailRequest

### DIFF
--- a/Nexus.Sdk.Shared/Requests/CreateMailRequest.cs
+++ b/Nexus.Sdk.Shared/Requests/CreateMailRequest.cs
@@ -12,7 +12,7 @@ public class CreateMailRequest
 
     [JsonPropertyName("references")]
     [Required]
-    public required MailEntityCodes? References { get; set; }
+    public required MailEntityCodes References { get; set; }
 
     [JsonPropertyName("content")]
     public MailContent? Content { get; set; }

--- a/Nexus.Sdk.Shared/Requests/CreateMailRequest.cs
+++ b/Nexus.Sdk.Shared/Requests/CreateMailRequest.cs
@@ -11,7 +11,8 @@ public class CreateMailRequest
     public required string Type { get; set; }
 
     [JsonPropertyName("references")]
-    public MailEntityCodes? References { get; set; }
+    [Required]
+    public required MailEntityCodes? References { get; set; }
 
     [JsonPropertyName("content")]
     public MailContent? Content { get; set; }


### PR DESCRIPTION
The References property in the CreateMailRequest class has been modified. Previously, it was an optional property of type MailEntityCodes?. The changes make it a required property by adding the [Required] attribute and changing the property declaration to public required MailEntityCodes? References { get; set; }.