### PR TITLE
NXS-6462: update the token sdk to dotnet 9

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -24,6 +24,8 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 9.0.x
+    - name: Clear NuGet cache
+      run: dotnet nuget locals all --clear        
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 9.0.x
     - name: Restore dependencies

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 9.0.x
     - name: Restore dependencies

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -21,9 +21,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 9.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -24,8 +24,6 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 9.0.x
-    - name: Clear NuGet cache
-      run: dotnet nuget locals all --clear        
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 9.0.x
+        dotnet-version: '9.0.x'
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/Nexus.Sdk.Shared.Tests/Nexus.Sdk.Shared.Tests.csproj
+++ b/Nexus.Sdk.Shared.Tests/Nexus.Sdk.Shared.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/Nexus.Sdk.Shared/Nexus.Sdk.Shared.csproj
+++ b/Nexus.Sdk.Shared/Nexus.Sdk.Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<PackageProjectUrl>https://github.com/QuantozTechnology/Nexus.Sdk.Dotnet/Nexus.Sdk.Shared</PackageProjectUrl>
@@ -18,10 +18,10 @@
 
   <ItemGroup>
     <PackageReference Include="IdentityModel" Version="7.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
-	<PackageReference Include="ReHackt.Extensions.Options.Validation" Version="8.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.0" />
+	<PackageReference Include="ReHackt.Extensions.Options.Validation" Version="9.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Nexus.Sdk.Shared/Nexus.Sdk.Shared.csproj
+++ b/Nexus.Sdk.Shared/Nexus.Sdk.Shared.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.0" />
-	<PackageReference Include="ReHackt.Extensions.Options.Validation" Version="9.0.0" />
+	<PackageReference Include="ReHackt.Extensions.Options.Validation" Version="8.0.2" />
   </ItemGroup>
 
 </Project>

--- a/Nexus.Sdk.Token.Tests/Nexus.Sdk.Token.Tests.csproj
+++ b/Nexus.Sdk.Token.Tests/Nexus.Sdk.Token.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/Nexus.Sdk.Token/Nexus.Sdk.Token.csproj
+++ b/Nexus.Sdk.Token/Nexus.Sdk.Token.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<PackageProjectUrl>https://github.com/QuantozTechnology/Nexus.Sdk.Dotnet/Nexus.Sdk.Token</PackageProjectUrl>
@@ -16,7 +16,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Algorand" Version="0.2.1" />
+		<PackageReference Include="Algorand" Version="0.2.2-beta18" />
 		<PackageReference Include="ReHackt.Extensions.Options.Validation" Version="8.0.2" />
 		<PackageReference Include="stellar-dotnet-sdk" Version="9.1.3" />
 	</ItemGroup>

--- a/Nexus.Sdk.Token/Nexus.Sdk.Token.csproj
+++ b/Nexus.Sdk.Token/Nexus.Sdk.Token.csproj
@@ -16,7 +16,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Algorand" Version="0.2.2-beta18" />
+		<PackageReference Include="Algorand" Version="0.2.1" />
 		<PackageReference Include="ReHackt.Extensions.Options.Validation" Version="8.0.2" />
 		<PackageReference Include="stellar-dotnet-sdk" Version="9.1.3" />
 	</ItemGroup>

--- a/Nexus.Sdk.Token/TokenServerProvider.cs
+++ b/Nexus.Sdk.Token/TokenServerProvider.cs
@@ -912,9 +912,13 @@ namespace Nexus.Sdk.Token
             var request = new UpdateOperationStatusRequest
             {
                 Status = status,
-                PaymentReference = paymentReference,
-                Comment = comment
+                PaymentReference = paymentReference
             };
+
+            if (comment != null)
+            {
+                request.Comment = comment;
+            }
 
             return await builder.ExecutePut<UpdateOperationStatusRequest, TokenOperationResponse>(request);
         }

--- a/Nexus.Token.Algorand.Examples/Nexus.Token.Algorand.Examples.csproj
+++ b/Nexus.Token.Algorand.Examples/Nexus.Token.Algorand.Examples.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<UserSecretsId>1fd3e177-39e7-4196-8213-81d984178923</UserSecretsId>

--- a/Nexus.Token.Stellar.Examples/Nexus.Token.Stellar.Examples.csproj
+++ b/Nexus.Token.Stellar.Examples/Nexus.Token.Stellar.Examples.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UserSecretsId>b12a33fa-9ffa-4b40-bd02-0e4a497f6675</UserSecretsId>


### PR DESCRIPTION
- Updated workflow and project files to dotnet 9. 
- Checked package references for compatibility and updated where necessary.
- Fixed bug encountered while testing Algorand and Stellar scenarios in dotnet 9.