### PR TITLE
Add virtual account creation functionality

### DIFF
--- a/Nexus.Sdk.Token.Tests/Helpers/MockTokenServerProvider.cs
+++ b/Nexus.Sdk.Token.Tests/Helpers/MockTokenServerProvider.cs
@@ -347,11 +347,11 @@ namespace Nexus.Sdk.Token.Tests.Helpers
         {
             throw new NotImplementedException();
         }
-        
+
         public Task<TokenOperationResponse> UpdateOperationStatusAsync(string operationCode, string status, string? comment = null, string? customerIPAddress = null, string? paymentReference = null)
         {
             var tokenOperationResponse = new TokenOperationResponse
-            (  
+            (
                 code: "MockCode",
                 hash: "MockHash",
                 senderAccount: new OperationAccountResponses(
@@ -379,7 +379,7 @@ namespace Nexus.Sdk.Token.Tests.Helpers
                 blockchainTransactionId: "MockBlockchainTransactionId",
                 fees: new OperationFees {
                     BankFees = new OperationBankFees {
-                        TotalFiat = 100        
+                        TotalFiat = 100
                     },
                     PartnerFees = new OperationPartnerFees {
                         TotalFiat = 100
@@ -420,6 +420,11 @@ namespace Nexus.Sdk.Token.Tests.Helpers
         }
 
         public Task DeleteBankAccount(DeleteBankAccountRequest request)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<AccountResponse> CreateVirtualAccount(string customerCode, bool generateReceiveAddress, string cryptoCode, IEnumerable<string> allowedTokens, string? customerIPAddress = null, string? customName = null)
         {
             throw new NotImplementedException();
         }

--- a/Nexus.Sdk.Token/Facades/AccountsFacade.cs
+++ b/Nexus.Sdk.Token/Facades/AccountsFacade.cs
@@ -30,6 +30,11 @@ public class AccountsFacade : TokenServerFacade, IAccountsFacade
         return await _provider.UpdateAccount(customerCode, accountCode, updateRequest, customerIPAddress);
     }
 
+    public async Task<AccountResponse> CreateVirtualAccount(string customerCode, bool generateReceiveAddress, string cryptoCode, IEnumerable<string> allowedTokens, string? customerIPAddress = null, string? customName = null)
+    {
+        return await _provider.CreateVirtualAccount(customerCode, generateReceiveAddress, cryptoCode, allowedTokens, customerIPAddress, customName);
+    }
+
     public async Task<AccountResponse> CreateOnStellarAsync(string customerCode, string publicKey, string? customerIPAddress = null, string? customName = null, string? accountType = "MANAGED")
     {
         return await _provider.CreateAccountOnStellarAsync(customerCode, publicKey, customerIPAddress, customName, accountType);

--- a/Nexus.Sdk.Token/Facades/Interfaces/IAccountsFacade.cs
+++ b/Nexus.Sdk.Token/Facades/Interfaces/IAccountsFacade.cs
@@ -23,6 +23,18 @@ public interface IAccountsFacade
     public Task<AccountBalancesResponse> GetBalances(string accountCode);
 
     /// <summary>
+    /// Create a virtual account
+    /// </summary>
+    /// <param name="customerCode">Unique Nexus identifier of the customer.</param>
+    /// <param name="generateReceiveAddress">Generate a receive address for the virtual account to receive from blockchain accounts.</param>
+    /// <param name="cryptoCode">Blockchain to connect this account to.</param>
+    /// <param name="allowedTokens">A list of token codes the account will be connected to upon creation</param>
+    /// <param name="customerIPAddress">Optional IP address of the customer used for tracing their actions</param>
+    /// <param name="customName">Optional custom name for account</param>
+    /// <returns></returns>
+    Task<AccountResponse> CreateVirtualAccount(string customerCode, bool generateReceiveAddress, string cryptoCode, IEnumerable<string> allowedTokens, string? customerIPAddress = null, string? customName = null);
+
+    /// <summary>
     /// Create a new account on the Stellar blockchain
     /// </summary>
     /// <param name="customerCode">Unique Nexus identifier of the customer.</param>
@@ -32,7 +44,6 @@ public interface IAccountsFacade
     /// <param name="accountType">Optional type for account (Defaults to a managed account)</param>
     /// <returns>The Nexus account that is created</returns>
     public Task<AccountResponse> CreateOnStellarAsync(string customerCode, string publicKey, string? customerIPAddress = null, string? customName = null, string? accountType = "MANAGED");
-
 
     /// <summary>
     /// Create a new account on the Stellar blockchain and connect it with tokens

--- a/Nexus.Sdk.Token/ITokenServerProvider.cs
+++ b/Nexus.Sdk.Token/ITokenServerProvider.cs
@@ -17,6 +17,16 @@ namespace Nexus.Sdk.Token
         Task<PagedResponse<AccountResponse>> GetAccounts(IDictionary<string, string>? query);
 
         /// <summary>
+        /// Create a virtual account
+        /// </summary>
+        /// <param name="customerCode"></param>
+        /// <param name="generateReceiveAddress">Generate a receive address for the virtual account to receive from blockchain accounts.</param>
+        /// <param name="customerIPAddress">Optional IP address of the customer used for tracing their actions</param>
+        /// <param name="customName">Optional custom name for account</param>
+        /// <returns></returns>
+        Task<AccountResponse> CreateVirtualAccount(string customerCode, bool generateReceiveAddress, string cryptoCode, IEnumerable<string> allowedTokens, string? customerIPAddress = null, string? customName = null);
+
+        /// <summary>
         ///
         /// </summary>
         /// <param name="customerCode"></param>

--- a/Nexus.Sdk.Token/Requests/AccountRequests.cs
+++ b/Nexus.Sdk.Token/Requests/AccountRequests.cs
@@ -23,6 +23,15 @@ public record CreateStellarAccountRequest : CreateTokenAccountRequest
     public string CryptoCode { get; set; } = "XLM";
 }
 
+public record CreateVirtualAccountRequest : CreateTokenAccountRequest
+{
+    [JsonPropertyName("cryptoCode")]
+    public string CryptoCode { get; set; }
+
+    [JsonPropertyName("generateReceiveAddress")]
+    public bool GenerateReceiveAddress { get; set; }
+}
+
 public record CreateAlgorandAccountRequest : CreateTokenAccountRequest
 {
     [JsonPropertyName("cryptoCode")]

--- a/Nexus.Sdk.Token/TokenServerProvider.cs
+++ b/Nexus.Sdk.Token/TokenServerProvider.cs
@@ -72,6 +72,33 @@ namespace Nexus.Sdk.Token
 
             return await builder.ExecutePut<UpdateTokenAccountRequest, SignableResponse>(request);
         }
+        public async Task<AccountResponse> CreateVirtualAccount(string customerCode, bool generateReceiveAddress, string cryptoCode, IEnumerable<string> allowedTokens, string? customerIPAddress = null, string? customName = null)
+        {
+            var builder = new RequestBuilder(_client, _handler, _logger).SetSegments("customer", customerCode, "accounts");
+
+            if (customerIPAddress != null)
+            {
+                builder.AddHeader("customer_ip_address", customerIPAddress);
+            }
+
+            var request = new CreateVirtualAccountRequest
+            {
+                GenerateReceiveAddress = generateReceiveAddress,
+                AccountType = "VIRTUAL",
+                CryptoCode = cryptoCode,
+                TokenSettings = new CreateTokenAccountSettings
+                {
+                    AllowedTokens = allowedTokens
+                }
+            };
+
+            if (!string.IsNullOrWhiteSpace(customName))
+            {
+                request.CustomName = customName;
+            }
+
+            return await builder.ExecutePost<CreateVirtualAccountRequest, AccountResponse>(request);
+        }
 
         /// <summary>
         ///


### PR DESCRIPTION
- Add `CreateVirtualAccount` method in `AccountsFacade` and `ITokenServerProvider` interfaces.
- Enhance `IAccountsFacade` with detailed documentation for `CreateVirtualAccount`.
- Introduce `CreateVirtualAccountRequest` record in `AccountRequests.cs`.
- Implement `CreateVirtualAccount` in `TokenServerProvider.cs` to handle account creation requests.