### PR TITLE
NXS-6879: Add address parameter to CreateVirtualAccount method

### DIFF
--- a/Nexus.Sdk.Token.Tests/Helpers/MockTokenServerProvider.cs
+++ b/Nexus.Sdk.Token.Tests/Helpers/MockTokenServerProvider.cs
@@ -424,7 +424,7 @@ namespace Nexus.Sdk.Token.Tests.Helpers
             throw new NotImplementedException();
         }
 
-        public Task<AccountResponse> CreateVirtualAccount(string customerCode, bool generateReceiveAddress, string cryptoCode, IEnumerable<string> allowedTokens, string? customerIPAddress = null, string? customName = null)
+        public Task<AccountResponse> CreateVirtualAccount(string customerCode, string address, bool generateReceiveAddress, string cryptoCode, IEnumerable<string> allowedTokens, string? customerIPAddress = null, string? customName = null)
         {
             throw new NotImplementedException();
         }

--- a/Nexus.Sdk.Token/Facades/AccountsFacade.cs
+++ b/Nexus.Sdk.Token/Facades/AccountsFacade.cs
@@ -30,9 +30,9 @@ public class AccountsFacade : TokenServerFacade, IAccountsFacade
         return await _provider.UpdateAccount(customerCode, accountCode, updateRequest, customerIPAddress);
     }
 
-    public async Task<AccountResponse> CreateVirtualAccount(string customerCode, bool generateReceiveAddress, string cryptoCode, IEnumerable<string> allowedTokens, string? customerIPAddress = null, string? customName = null)
+    public async Task<AccountResponse> CreateVirtualAccount(string customerCode, string address, bool generateReceiveAddress, string cryptoCode, IEnumerable<string> allowedTokens, string? customerIPAddress = null, string? customName = null)
     {
-        return await _provider.CreateVirtualAccount(customerCode, generateReceiveAddress, cryptoCode, allowedTokens, customerIPAddress, customName);
+        return await _provider.CreateVirtualAccount(customerCode, address, generateReceiveAddress, cryptoCode, allowedTokens, customerIPAddress, customName);
     }
 
     public async Task<AccountResponse> CreateOnStellarAsync(string customerCode, string publicKey, string? customerIPAddress = null, string? customName = null, string? accountType = "MANAGED")

--- a/Nexus.Sdk.Token/Facades/Interfaces/IAccountsFacade.cs
+++ b/Nexus.Sdk.Token/Facades/Interfaces/IAccountsFacade.cs
@@ -26,13 +26,14 @@ public interface IAccountsFacade
     /// Create a virtual account
     /// </summary>
     /// <param name="customerCode">Unique Nexus identifier of the customer.</param>
+    /// <param name="address">Optionally supply a receive address for the virtual account to receive from blockchain accounts.</param>
     /// <param name="generateReceiveAddress">Generate a receive address for the virtual account to receive from blockchain accounts.</param>
     /// <param name="cryptoCode">Blockchain to connect this account to.</param>
     /// <param name="allowedTokens">A list of token codes the account will be connected to upon creation</param>
     /// <param name="customerIPAddress">Optional IP address of the customer used for tracing their actions</param>
     /// <param name="customName">Optional custom name for account</param>
     /// <returns></returns>
-    Task<AccountResponse> CreateVirtualAccount(string customerCode, bool generateReceiveAddress, string cryptoCode, IEnumerable<string> allowedTokens, string? customerIPAddress = null, string? customName = null);
+    Task<AccountResponse> CreateVirtualAccount(string customerCode, string address, bool generateReceiveAddress, string cryptoCode, IEnumerable<string> allowedTokens, string? customerIPAddress = null, string? customName = null);
 
     /// <summary>
     /// Create a new account on the Stellar blockchain

--- a/Nexus.Sdk.Token/ITokenServerProvider.cs
+++ b/Nexus.Sdk.Token/ITokenServerProvider.cs
@@ -20,13 +20,14 @@ namespace Nexus.Sdk.Token
         /// Create a virtual account
         /// </summary>
         /// <param name="customerCode">Unique Nexus identifier of the customer.</param>
+        /// <param name="address">Optionally supply a receive address to receive from blockchain accounts.</param>
         /// <param name="generateReceiveAddress">Generate a receive address for the virtual account to receive from blockchain accounts.</param>
-       /// <param name="cryptoCode">Blockchain to connect this account to.</param>
-       /// <param name="allowedTokens">A list of token codes the account will be connected to upon creation</param>
-       /// <param name="customerIPAddress">Optional IP address of the customer used for tracing their actions</param>
-       /// <param name="customName">Optional custom name for account</param>
-       /// <returns></returns>
-        Task<AccountResponse> CreateVirtualAccount(string customerCode, bool generateReceiveAddress, string cryptoCode, IEnumerable<string> allowedTokens, string? customerIPAddress = null, string? customName = null);
+        /// <param name="cryptoCode">Blockchain to connect this account to.</param>
+        /// <param name="allowedTokens">A list of token codes the account will be connected to upon creation</param>
+        /// <param name="customerIPAddress">Optional IP address of the customer used for tracing their actions</param>
+        /// <param name="customName">Optional custom name for account</param>
+        /// <returns></returns>
+        Task<AccountResponse> CreateVirtualAccount(string customerCode, string address, bool generateReceiveAddress, string cryptoCode, IEnumerable<string> allowedTokens, string? customerIPAddress = null, string? customName = null);
 
         /// <summary>
         ///

--- a/Nexus.Sdk.Token/TokenServerProvider.cs
+++ b/Nexus.Sdk.Token/TokenServerProvider.cs
@@ -72,8 +72,13 @@ namespace Nexus.Sdk.Token
 
             return await builder.ExecutePut<UpdateTokenAccountRequest, SignableResponse>(request);
         }
-        public async Task<AccountResponse> CreateVirtualAccount(string customerCode, bool generateReceiveAddress, string cryptoCode, IEnumerable<string> allowedTokens, string? customerIPAddress = null, string? customName = null)
+        public async Task<AccountResponse> CreateVirtualAccount(string customerCode, string address, bool generateReceiveAddress, string cryptoCode, IEnumerable<string> allowedTokens, string? customerIPAddress = null, string? customName = null)
         {
+            if (!string.IsNullOrWhiteSpace(address) && generateReceiveAddress)
+            {
+                throw new InvalidOperationException("Supplying an address and requesting one to be generated is unsupported.");
+            }
+
             var builder = new RequestBuilder(_client, _handler, _logger).SetSegments("customer", customerCode, "accounts");
 
             if (customerIPAddress != null)
@@ -84,6 +89,7 @@ namespace Nexus.Sdk.Token
             var request = new CreateVirtualAccountRequest
             {
                 GenerateReceiveAddress = generateReceiveAddress,
+                Address = address,
                 AccountType = "VIRTUAL",
                 CryptoCode = cryptoCode,
                 TokenSettings = new CreateTokenAccountSettings


### PR DESCRIPTION
Updated the CreateVirtualAccount method in AccountsFacade to include an optional address parameter for supplying a receive address. Adjusted method implementation to handle the new parameter and throw an exception if both address and generateReceiveAddress are provided. Updated IAccountsFacade and ITokenServerProvider interfaces accordingly, along with documentation comments to reflect these changes.