### PR TITLE
NXS-6900: Fix incorrect namespaces

### DIFF
--- a/Nexus.Sdk.Token/ITokenServerProvider.cs
+++ b/Nexus.Sdk.Token/ITokenServerProvider.cs
@@ -1,5 +1,4 @@
 ﻿using Nexus.Sdk.Shared;
-using Nexus.Sdk.Shared.Requests;
 using Nexus.Sdk.Shared.Responses;
 using Nexus.Sdk.Token.Requests;
 using Nexus.Sdk.Token.Responses;

--- a/Nexus.Sdk.Token/Requests/DocumentListRequest.cs
+++ b/Nexus.Sdk.Token/Requests/DocumentListRequest.cs
@@ -1,7 +1,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 
-namespace Nexus.Sdk.Shared.Requests;
+namespace Nexus.Sdk.Token.Requests;
 
 public class DocumentListRequest
 {

--- a/Nexus.Sdk.Token/Requests/DocumentRequest.cs
+++ b/Nexus.Sdk.Token/Requests/DocumentRequest.cs
@@ -1,7 +1,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 
-namespace Nexus.Sdk.Shared.Requests;
+namespace Nexus.Sdk.Token.Requests;
 
 public class DocumentRequest
 {

--- a/Nexus.Sdk.Token/Requests/DocumentStoreSettingsRequest.cs
+++ b/Nexus.Sdk.Token/Requests/DocumentStoreSettingsRequest.cs
@@ -1,7 +1,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 
-namespace Nexus.Sdk.Shared.Requests;
+namespace Nexus.Sdk.Token.Requests;
 
 public class DocumentStoreSettingsRequest
 {

--- a/Nexus.Sdk.Token/Requests/FileUploadRequest.cs
+++ b/Nexus.Sdk.Token/Requests/FileUploadRequest.cs
@@ -2,7 +2,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Http;
 
-namespace Nexus.Sdk.Shared.Requests;
+namespace Nexus.Sdk.Token.Requests;
 
 public class FileUploadRequest
 {

--- a/Nexus.Sdk.Token/Responses/DocumentStoreItemResponse.cs
+++ b/Nexus.Sdk.Token/Responses/DocumentStoreItemResponse.cs
@@ -1,6 +1,6 @@
 using System.Text.Json.Serialization;
 
-namespace Nexus.Sdk.Shared.Responses;
+namespace Nexus.Sdk.Token.Responses;
 
 public class DocumentStoreItemResponse
 {

--- a/Nexus.Sdk.Token/Responses/DocumentStoreSettingsResponses.cs
+++ b/Nexus.Sdk.Token/Responses/DocumentStoreSettingsResponses.cs
@@ -1,6 +1,6 @@
 using System.Text.Json.Serialization;
 
-namespace Nexus.Sdk.Shared.Responses;
+namespace Nexus.Sdk.Token.Responses;
 
 public record DocumentStoreSettingsResponse
 {


### PR DESCRIPTION
Fixed the Document API request and response file namespaces.