### PR TITLE
NXS-6910: Add Document File Update API

### DIFF
--- a/Nexus.Sdk.Token.Tests/Helpers/MockTokenServerProvider.cs
+++ b/Nexus.Sdk.Token.Tests/Helpers/MockTokenServerProvider.cs
@@ -466,5 +466,10 @@ namespace Nexus.Sdk.Token.Tests.Helpers
         {
             throw new NotImplementedException();
         }
+
+        public Task UpdateDocumentInStore(FileUpdateRequest fileUpdateRequest, string customerIPAddress)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/Nexus.Sdk.Token/ITokenServerProvider.cs
+++ b/Nexus.Sdk.Token/ITokenServerProvider.cs
@@ -464,5 +464,13 @@ namespace Nexus.Sdk.Token
         /// <param name="customerIPAddress"></param>
         /// <returns></returns>
         Task DeleteDocumentFromStore(DocumentRequest documentRequest, string customerIPAddress);
+
+        /// <summary>
+        /// Update document metadata in the Document Store
+        /// </summary>
+        /// <param name="fileUpdateRequest"></param>
+        /// <param name="customerIPAddress"></param>
+        /// <returns></returns>
+        Task UpdateDocumentInStore(FileUpdateRequest fileUpdateRequest, string customerIPAddress);
     }
 }

--- a/Nexus.Sdk.Token/Requests/DocumentStoreSettingsRequest.cs
+++ b/Nexus.Sdk.Token/Requests/DocumentStoreSettingsRequest.cs
@@ -25,7 +25,8 @@ public class DocumentStoreSettingsRequest
     /// <remarks>
     /// Currently only Azure Files is supported.
     /// </remarks>
-    [JsonPropertyName("documentStoreType")]
+    // This JSON property name is case-sensitive. Todo: fix this issue in Nexus 
+    [JsonPropertyName("DocumentStoreType")]
     [Required]
     public required string DocumentStoreType { get; set; }
 

--- a/Nexus.Sdk.Token/Requests/FileUpdateRequest.cs
+++ b/Nexus.Sdk.Token/Requests/FileUpdateRequest.cs
@@ -1,0 +1,53 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace Nexus.Sdk.Token.Requests;
+
+public class FileUpdateRequest
+{
+    /// <summary>
+    /// The path of the file in the Document Store
+    /// </summary>
+    /// <example>
+    /// path/to/file.txt
+    /// </example>
+    [JsonPropertyName("filePath")]
+    [Required]
+    [StringLength(255)]
+    public required string FilePath { get; set; }
+
+    /// <summary>
+    /// The DocumentTypeCode is used to identify the type of document associated with the file.
+    /// </summary>
+    [JsonPropertyName("documentTypeCode")]
+    [StringLength(40)]
+    public string DocumentTypeCode { get; set; }
+
+    /// <summary>
+    /// An optional alias for the file. 
+    /// </summary>
+
+    [StringLength(50)]
+    public string Alias { get; set; }
+
+    /// <summary>
+    /// An optional description of the file.
+    /// </summary>
+    [JsonPropertyName("description")]
+    [StringLength(100)]
+    public string Description { get; set; }
+
+    /// <summary>
+    /// A Customer code is used to identify the customer associated with the file.
+    /// </summary>
+    [JsonPropertyName("customerCode")]
+    [StringLength(40)]
+    public string CustomerCode { get; set; }
+
+    /// <summary>
+    /// An optional external unique identifier for the file.
+    /// </summary>
+    [JsonPropertyName("itemReference")]
+    [StringLength(40)]
+    public string ItemReference { get; set; }
+}

--- a/Nexus.Sdk.Token/TokenServerProvider.cs
+++ b/Nexus.Sdk.Token/TokenServerProvider.cs
@@ -1216,5 +1216,22 @@ namespace Nexus.Sdk.Token
 
             await builder.ExecuteDelete<NexusResponse>();
         }
+
+        /// <summary>
+        /// Update document metadata in the Document Store.
+        /// </summary>
+        /// <param name="fileUpdateRequest"></param>
+        /// <param name="customerIPAddress"></param>
+        /// <returns></returns>
+        public async Task UpdateDocumentInStore(FileUpdateRequest fileUpdateRequest, string customerIPAddress)
+        {
+            var builder = new RequestBuilder(_client, _handler, _logger)
+                .SetSegments("integrations", "documentstore", "file");
+
+            builder.AddHeader("customer_ip_address", customerIPAddress);
+
+
+            await builder.ExecutePut<FileUpdateRequest, NexusResponse>(fileUpdateRequest);
+        }
     }
 }


### PR DESCRIPTION
### Improvement
Add the Document File Update API to the SDK.  

**Changes**
* **Interface update**: Added the `UpdateDocumentInStore` method to the `ITokenServerProvider` interface to support document metadata updates.
* **Implementation**: Added the `UpdateDocumentInStore` method to the `TokenServerProvider` class, which constructs and executes a PUT request to update document metadata.
* **`FileUpdateRequest` class**: Created a new model to encapsulate file metadata updates, including properties for file path, document type code, alias, description, customer code, and item reference. Added validation attributes for required fields and constraints.

### Fix for JSON property naming:
* **Case-sensitivity issue**: Updated the `DocumentStoreType` property in `DocumentStoreSettingsRequest` to use a case-sensitive JSON property name (`"DocumentStoreType"`) and added a comment noting the need for a future fix in Nexus.