### PR TITLE
NXS-7014: Document deletion and viewing fails for certain files

### DIFF
--- a/Nexus.Sdk.Token/Requests/DocumentRequest.cs
+++ b/Nexus.Sdk.Token/Requests/DocumentRequest.cs
@@ -5,14 +5,23 @@ namespace Nexus.Sdk.Token.Requests;
 
 public class DocumentRequest
 {
+    private string _filePath = string.Empty;
+
     /// <summary>
     /// The path of the file in the Document Store
     /// </summary>
     /// <example>
     /// path/to/file.txt
     /// </example>
+    /// <remarks>
+    /// The path is automatically URL-encoded to ensure it is safe for transmission
+    /// </remarks>
     [JsonPropertyName("filePath")]
     [Required]
     [StringLength(255)]
-    public required string FilePath { get; set; }
+    public required string FilePath
+    {
+        get => _filePath;
+        set => _filePath = Uri.EscapeDataString(value);
+    }
 }


### PR DESCRIPTION
### Issue
Document file names containing a plus symbol cannot be viewed or deleted. This is due to the document path being passed as a query parameter (e.g., ?filePath=file+example.pdf) to the `GET` and `DELETE` Document endpoints without URL encoding. As a result the plus symbol will be decoded as a space on the server side.

### Improvement
This pull request introduces an enhancement to the `DocumentRequest` class in the `Nexus.Sdk.Token.Requests` namespace to improve the handling of file paths. The `FilePath` property value is automatically URL encoded to ensure correct transmission of the document file path.