### PR TITLE
NXS-7652: Virtual IBAN SDK changes

### DIFF
--- a/Nexus.Sdk.Token.Tests/Helpers/MockTokenServerProvider.cs
+++ b/Nexus.Sdk.Token.Tests/Helpers/MockTokenServerProvider.cs
@@ -27,6 +27,11 @@ namespace Nexus.Sdk.Token.Tests.Helpers
             throw new NotImplementedException();
         }
 
+        public Task<SignableResponse> ConnectAccountToTokensAsync(string accountCode, IEnumerable<TokenCodeWithData> tokensWithData, string? customerIPAddress = null)
+        {
+            throw new NotImplementedException();
+        }
+
         public Task<AccountResponse> CreateAccountOnAlgorandAsync(string customerCode, string publicKey, string? customerIPAddress = null, string? customName = null, string? accountType = "MANAGED")
         {
             throw new NotImplementedException();
@@ -37,7 +42,17 @@ namespace Nexus.Sdk.Token.Tests.Helpers
             throw new NotImplementedException();
         }
 
+        public Task<SignableResponse> CreateAccountOnAlgorandAsync(string customerCode, string publicKey, IEnumerable<TokenCodeWithData> tokensWithData, string? customerIPAddress = null, string? customName = null, string? accountType = "MANAGED")
+        {
+            throw new NotImplementedException();
+        }
+
         public Task<SignableResponse> CreateAccountOnStellarAsync(string customerCode, string publicKey, IEnumerable<string> tokenCodes, string? customerIPAddress = null, string? customName = null, string? accountType = "MANAGED")
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<SignableResponse> CreateAccountOnStellarAsync(string customerCode, string publicKey, IEnumerable<TokenCodeWithData> tokensWithData, string? customerIPAddress = null, string? customName = null, string? accountType = "MANAGED")
         {
             throw new NotImplementedException();
         }
@@ -436,6 +451,11 @@ namespace Nexus.Sdk.Token.Tests.Helpers
         }
 
         public Task<AccountResponse> CreateVirtualAccount(string customerCode, string address, bool generateReceiveAddress, string cryptoCode, IEnumerable<string> allowedTokens, string? customerIPAddress = null, string? customName = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<AccountResponse> CreateVirtualAccount(string customerCode, string address, bool generateReceiveAddress, string cryptoCode, IEnumerable<TokenCodeWithData> tokensWithData, string? customerIPAddress = null, string? customName = null)
         {
             throw new NotImplementedException();
         }

--- a/Nexus.Sdk.Token.Tests/Helpers/MockTokenServerProvider.cs
+++ b/Nexus.Sdk.Token.Tests/Helpers/MockTokenServerProvider.cs
@@ -197,6 +197,13 @@ namespace Nexus.Sdk.Token.Tests.Helpers
             throw new NotImplementedException();
         }
 
+        public Task<PagedResponse<AccountTokenResponse>> GetAccountTokensAsync(IDictionary<string, string>? queryParameters)
+        {
+            var accountToken = new AccountTokenResponse("ACC001", "TOKEN001", "ACTIVE", new Dictionary<string, string> { { "VIBANNUMBER", "NL91ABNA0417164300" } });
+            var pagedResponse = new PagedResponse<AccountTokenResponse>(1, 1, 1, new Dictionary<string, string>(), new[] { accountToken });
+            return Task.FromResult(pagedResponse);
+        }
+
         public Task<CustomerResponse> GetCustomer(string customerCode)
         {
             throw new NotImplementedException();

--- a/Nexus.Sdk.Token.Tests/MockTokenServerProviderTests.cs
+++ b/Nexus.Sdk.Token.Tests/MockTokenServerProviderTests.cs
@@ -103,5 +103,40 @@ namespace Nexus.Sdk.Token.Tests
                 Assert.That(tokenOperationResponse.Fees?.NetworkFees?.EstimatedCrypto, Is.EqualTo(100));
             });
         }
+
+        [Test]
+        public async Task MockTokenServerProviderTests_GetAccountTokensAsync()
+        {
+            _services = new ServiceCollection();
+
+            var mock = new MockTokenServerProvider();
+
+            _services.AddTokenServer(mock);
+
+            var provider = _services.BuildServiceProvider();
+
+            var tokenServerProvider = provider.GetRequiredService<ITokenServerProvider>();
+
+            var queryParameters = new Dictionary<string, string> { { "data_VIBANNUMBER", "NL91ABNA0417164300" } };
+            var pagedResponse = await tokenServerProvider.GetAccountTokensAsync(queryParameters);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(tokenServerProvider, Is.Not.Null);
+                Assert.That(pagedResponse, Is.Not.Null);
+                Assert.That(pagedResponse.Records, Is.Not.Null);
+                Assert.That(pagedResponse.Page, Is.EqualTo(1));
+                Assert.That(pagedResponse.Total, Is.EqualTo(1));
+                Assert.That(pagedResponse.TotalPages, Is.EqualTo(1));
+
+                var firstRecord = pagedResponse.Records.FirstOrDefault();
+                Assert.That(firstRecord, Is.Not.Null);
+                Assert.That(firstRecord!.AccountCode, Is.Not.Null.Or.Empty);
+                Assert.That(firstRecord.TokenCode, Is.Not.Null.Or.Empty);
+                Assert.That(firstRecord.Status, Is.Not.Null.Or.Empty);
+                Assert.That(firstRecord.Data, Is.Not.Null);
+                Assert.That(firstRecord.Data!["VIBANNUMBER"], Is.EqualTo("NL91ABNA0417164300"));
+            });
+        }
     }
 }

--- a/Nexus.Sdk.Token/Facades/AccountsFacade.cs
+++ b/Nexus.Sdk.Token/Facades/AccountsFacade.cs
@@ -35,6 +35,11 @@ public class AccountsFacade : TokenServerFacade, IAccountsFacade
         return await _provider.CreateVirtualAccount(customerCode, address, generateReceiveAddress, cryptoCode, allowedTokens, customerIPAddress, customName);
     }
 
+    public async Task<AccountResponse> CreateVirtualAccount(string customerCode, string address, bool generateReceiveAddress, string cryptoCode, IEnumerable<TokenCodeWithData> tokensWithData, string? customerIPAddress = null, string? customName = null)
+    {
+        return await _provider.CreateVirtualAccount(customerCode, address, generateReceiveAddress, cryptoCode, tokensWithData, customerIPAddress, customName);
+    }
+
     public async Task<AccountResponse> CreateOnStellarAsync(string customerCode, string publicKey, string? customerIPAddress = null, string? customName = null, string? accountType = "MANAGED")
     {
         return await _provider.CreateAccountOnStellarAsync(customerCode, publicKey, customerIPAddress, customName, accountType);
@@ -43,6 +48,11 @@ public class AccountsFacade : TokenServerFacade, IAccountsFacade
     public async Task<SignableResponse> CreateOnStellarAsync(string customerCode, string publicKey, IEnumerable<string> allowedTokens, string? customerIPAddress = null, string? customName = null, string? accountType = "MANAGED")
     {
         return await _provider.CreateAccountOnStellarAsync(customerCode, publicKey, allowedTokens, customerIPAddress, customName, accountType);
+    }
+
+    public async Task<SignableResponse> CreateOnStellarAsync(string customerCode, string publicKey, IEnumerable<TokenCodeWithData> tokensWithData, string? customerIPAddress = null, string? customName = null, string? accountType = "MANAGED")
+    {
+        return await _provider.CreateAccountOnStellarAsync(customerCode, publicKey, tokensWithData, customerIPAddress, customName, accountType);
     }
 
     public async Task<AccountResponse> CreateOnAlgorandAsync(string customerCode, string publicKey, string? customerIPAddress = null, string? customName = null, string? accountType = "MANAGED")
@@ -55,6 +65,11 @@ public class AccountsFacade : TokenServerFacade, IAccountsFacade
         return await _provider.CreateAccountOnAlgorandAsync(customerCode, publicKey, allowedTokens, customerIPAddress, customName, accountType);
     }
 
+    public async Task<SignableResponse> CreateOnAlgorandAsync(string customerCode, string publicKey, IEnumerable<TokenCodeWithData> tokensWithData, string? customerIPAddress = null, string? customName = null, string? accountType = "MANAGED")
+    {
+        return await _provider.CreateAccountOnAlgorandAsync(customerCode, publicKey, tokensWithData, customerIPAddress, customName, accountType);
+    }
+
     public async Task<SignableResponse> ConnectToTokenAsync(string accountCode, string tokenCode, string? customerIPAddress = null)
     {
         return await _provider.ConnectAccountToTokenAsync(accountCode, tokenCode, customerIPAddress);
@@ -63,6 +78,11 @@ public class AccountsFacade : TokenServerFacade, IAccountsFacade
     public async Task<SignableResponse> ConnectToTokensAsync(string accountCode, IEnumerable<string> tokenCodes, string? customerIPAddress = null)
     {
         return await _provider.ConnectAccountToTokensAsync(accountCode, tokenCodes, customerIPAddress);
+    }
+
+    public async Task<SignableResponse> ConnectToTokensAsync(string accountCode, IEnumerable<TokenCodeWithData> tokensWithData, string? customerIPAddress = null)
+    {
+        return await _provider.ConnectAccountToTokensAsync(accountCode, tokensWithData, customerIPAddress);
     }
 
     public async Task<NexusResponse> DeleteAccount(string accountCode)

--- a/Nexus.Sdk.Token/Facades/AccountsFacade.cs
+++ b/Nexus.Sdk.Token/Facades/AccountsFacade.cs
@@ -25,6 +25,33 @@ public class AccountsFacade : TokenServerFacade, IAccountsFacade
         return await _provider.GetAccountBalanceAsync(accountCode);
     }
 
+    public async Task<PagedResponse<AccountTokenResponse>> GetAccountTokensAsync(string? accountCode = null, string? tokenCode = null, IDictionary<string, string>? dataFilters = null, int page = 1, int limit = 50)
+    {
+        var query = new Dictionary<string, string>
+        {
+            { "page", page.ToString() },
+            { "limit", limit.ToString() }
+        };
+
+        if (!string.IsNullOrWhiteSpace(accountCode))
+        {
+            query["accountCode"] = accountCode;
+        }
+
+        if (!string.IsNullOrWhiteSpace(tokenCode))
+        {
+            query["tokenCode"] = tokenCode;
+        }
+        
+        if (dataFilters != null)
+        {
+            foreach (var (key, value) in dataFilters)
+                query[$"data_{key}"] = value;
+        }
+
+        return await _provider.GetAccountTokensAsync(query);
+    }
+
     public async Task<SignableResponse> Update(string customerCode, string accountCode, UpdateTokenAccountRequest updateRequest, string? customerIPAddress = null)
     {
         return await _provider.UpdateAccount(customerCode, accountCode, updateRequest, customerIPAddress);

--- a/Nexus.Sdk.Token/Facades/Interfaces/IAccountsFacade.cs
+++ b/Nexus.Sdk.Token/Facades/Interfaces/IAccountsFacade.cs
@@ -36,6 +36,19 @@ public interface IAccountsFacade
     Task<AccountResponse> CreateVirtualAccount(string customerCode, string address, bool generateReceiveAddress, string cryptoCode, IEnumerable<string> allowedTokens, string? customerIPAddress = null, string? customName = null);
 
     /// <summary>
+    /// Create a virtual account with optional per-token metadata
+    /// </summary>
+    /// <param name="customerCode">Unique Nexus identifier of the customer.</param>
+    /// <param name="address">Optionally supply a receive address for the virtual account to receive from blockchain accounts.</param>
+    /// <param name="generateReceiveAddress">Generate a receive address for the virtual account to receive from blockchain accounts.</param>
+    /// <param name="cryptoCode">Blockchain to connect this account to.</param>
+    /// <param name="tokensWithData">Token codes with optional metadata the account will be connected to upon creation</param>
+    /// <param name="customerIPAddress">Optional IP address of the customer used for tracing their actions</param>
+    /// <param name="customName">Optional custom name for account</param>
+    /// <returns></returns>
+    Task<AccountResponse> CreateVirtualAccount(string customerCode, string address, bool generateReceiveAddress, string cryptoCode, IEnumerable<TokenCodeWithData> tokensWithData, string? customerIPAddress = null, string? customName = null);
+
+    /// <summary>
     /// Create a new account on the Stellar blockchain
     /// </summary>
     /// <param name="customerCode">Unique Nexus identifier of the customer.</param>
@@ -57,6 +70,18 @@ public interface IAccountsFacade
     /// <param name="accountType">Optional type for account (Defaults to a managed account)</param>
     /// <returns>A transaction that needs to be signed using the private key that matches the provided public key</returns>
     public Task<SignableResponse> CreateOnStellarAsync(string customerCode, string publicKey, IEnumerable<string> allowedTokens, string? customerIPAddress = null, string? customName = null, string? accountType = "MANAGED");
+
+    /// <summary>
+    /// Create a new account on the Stellar blockchain, connecting it with tokens and optional per-token metadata
+    /// </summary>
+    /// <param name="customerCode">Unique Nexus identifier of the customer.</param>
+    /// <param name="publicKey">The public key the new Stellar account</param>
+    /// <param name="tokensWithData">Token codes with optional metadata the account will be connected to upon creation</param>
+    /// <param name="customerIPAddress">Optional IP address of the customer used for tracing their actions</param>
+    /// <param name="customName">Optional custom name for account</param>
+    /// <param name="accountType">Optional type for account (Defaults to a managed account)</param>
+    /// <returns>A transaction that needs to be signed using the private key that matches the provided public key</returns>
+    public Task<SignableResponse> CreateOnStellarAsync(string customerCode, string publicKey, IEnumerable<TokenCodeWithData> tokensWithData, string? customerIPAddress = null, string? customName = null, string? accountType = "MANAGED");
 
     /// <summary>
     /// Create a new account on the Algorand blockchain
@@ -82,6 +107,18 @@ public interface IAccountsFacade
     public Task<SignableResponse> CreateOnAlgorandAsync(string customerCode, string publicKey, IEnumerable<string> allowedTokens, string? customerIPAddress = null, string? customName = null, string? accountType = "MANAGED");
 
     /// <summary>
+    /// Create a new account on the Algorand blockchain, connecting it with tokens and optional per-token metadata
+    /// </summary>
+    /// <param name="customerCode">The code of the customer this account is created for</param>
+    /// <param name="publicKey">The public key the new Algorand account</param>
+    /// <param name="tokensWithData">Token codes with optional metadata the account will be connected to upon creation</param>
+    /// <param name="customerIPAddress">Optional IP address of the customer used for tracing their actions</param>
+    /// <param name="customName">Optional custom name for account</param>
+    /// <param name="accountType">Optional type for account (Defaults to a managed account)</param>
+    /// <returns>A transaction that needs to be signed using the private key that matches the provided public key</returns>
+    public Task<SignableResponse> CreateOnAlgorandAsync(string customerCode, string publicKey, IEnumerable<TokenCodeWithData> tokensWithData, string? customerIPAddress = null, string? customName = null, string? accountType = "MANAGED");
+
+    /// <summary>
     /// Connect a token to an account
     /// </summary>
     /// <param name="accountCode">{crypto}-{publickey} combination of the account. E.g. XLM-GAW6GBLA5U4KCXV4E5SZTVERBF3AUASEPNTN4ZXSXLCROOTJ7KQQW4S7</param>
@@ -98,6 +135,15 @@ public interface IAccountsFacade
     /// <param name="customerIPAddress">Optional IP address of the customer used for tracing their actions</param>
     /// <returns>A transaction that needs to be signed using the private key of the provided account</returns>
     public Task<SignableResponse> ConnectToTokensAsync(string accountCode, IEnumerable<string> tokenCodes, string? customerIPAddress = null);
+
+    /// <summary>
+    /// Connect tokens with optional per-token metadata to an account
+    /// </summary>
+    /// <param name="accountCode">{crypto}-{publickey} combination of the account. E.g. XLM-GAW6GBLA5U4KCXV4E5SZTVERBF3AUASEPNTN4ZXSXLCROOTJ7KQQW4S7</param>
+    /// <param name="tokensWithData">Token codes with optional metadata to associate with each token on this account</param>
+    /// <param name="customerIPAddress">Optional IP address of the customer used for tracing their actions</param>
+    /// <returns>A transaction that needs to be signed using the private key of the provided account</returns>
+    public Task<SignableResponse> ConnectToTokensAsync(string accountCode, IEnumerable<TokenCodeWithData> tokensWithData, string? customerIPAddress = null);
 
     /// <summary>
     /// Updates account properties

--- a/Nexus.Sdk.Token/Facades/Interfaces/IAccountsFacade.cs
+++ b/Nexus.Sdk.Token/Facades/Interfaces/IAccountsFacade.cs
@@ -23,6 +23,18 @@ public interface IAccountsFacade
     public Task<AccountBalancesResponse> GetBalances(string accountCode);
 
     /// <summary>
+    /// Get a paginated list of account tokens matching the provided search criteria.
+    /// At least one of accountCode, tokenCode, or dataFilters must be provided.
+    /// </summary>
+    /// <param name="accountCode">Optional account code to filter on.</param>
+    /// <param name="tokenCode">Optional token code to filter on.</param>
+    /// <param name="dataFilters">Optional data property filters (key=property_name, value=property_value). Keys will be prefixed with data_ when sent to the API.</param>
+    /// <param name="page">Page number (default 1).</param>
+    /// <param name="limit">Page size (default 50).</param>
+    /// <returns>A paged list of account tokens.</returns>
+    public Task<PagedResponse<AccountTokenResponse>> GetAccountTokensAsync(string? accountCode = null, string? tokenCode = null, IDictionary<string, string>? dataFilters = null, int page = 1, int limit = 50);
+
+    /// <summary>
     /// Create a virtual account
     /// </summary>
     /// <param name="customerCode">Unique Nexus identifier of the customer.</param>

--- a/Nexus.Sdk.Token/ITokenServerProvider.cs
+++ b/Nexus.Sdk.Token/ITokenServerProvider.cs
@@ -120,6 +120,13 @@ namespace Nexus.Sdk.Token
         Task<AccountBalancesResponse> GetAccountBalanceAsync(string accountCode);
 
         /// <summary>
+        /// Lists account tokens based on query parameters.
+        /// </summary>
+        /// <param name="queryParameters">Query parameters to filter on (accountCode, tokenCode, page, limit, data_* filters).</param>
+        /// <returns>A paged list of account tokens matching the search criteria.</returns>
+        Task<PagedResponse<AccountTokenResponse>> GetAccountTokensAsync(IDictionary<string, string>? queryParameters);
+
+        /// <summary>
         ///
         /// </summary>
         /// <param name="accountCode"></param>

--- a/Nexus.Sdk.Token/ITokenServerProvider.cs
+++ b/Nexus.Sdk.Token/ITokenServerProvider.cs
@@ -30,6 +30,19 @@ namespace Nexus.Sdk.Token
         Task<AccountResponse> CreateVirtualAccount(string customerCode, string address, bool generateReceiveAddress, string cryptoCode, IEnumerable<string> allowedTokens, string? customerIPAddress = null, string? customName = null);
 
         /// <summary>
+        /// Create a virtual account with optional per-token metadata
+        /// </summary>
+        /// <param name="customerCode">Unique Nexus identifier of the customer.</param>
+        /// <param name="address">Optionally supply a receive address to receive from blockchain accounts.</param>
+        /// <param name="generateReceiveAddress">Generate a receive address for the virtual account to receive from blockchain accounts.</param>
+        /// <param name="cryptoCode">Blockchain to connect this account to.</param>
+        /// <param name="tokensWithData">A list of token codes with optional metadata the account will be connected to upon creation</param>
+        /// <param name="customerIPAddress">Optional IP address of the customer used for tracing their actions</param>
+        /// <param name="customName">Optional custom name for account</param>
+        /// <returns></returns>
+        Task<AccountResponse> CreateVirtualAccount(string customerCode, string address, bool generateReceiveAddress, string cryptoCode, IEnumerable<TokenCodeWithData> tokensWithData, string? customerIPAddress = null, string? customName = null);
+
+        /// <summary>
         ///
         /// </summary>
         /// <param name="customerCode"></param>
@@ -51,6 +64,18 @@ namespace Nexus.Sdk.Token
         /// <param name="accountType">Optional type for account (Defaults to a managed account)</param>
         /// <returns></returns>
         Task<SignableResponse> CreateAccountOnStellarAsync(string customerCode, string publicKey, IEnumerable<string> tokenCodes, string? customerIPAddress = null, string? customName = null, string? accountType = "MANAGED");
+
+        /// <summary>
+        /// Create a new account on the Stellar blockchain, connecting it with tokens and optional per-token metadata
+        /// </summary>
+        /// <param name="customerCode"></param>
+        /// <param name="publicKey"></param>
+        /// <param name="tokensWithData">Token codes with optional metadata</param>
+        /// <param name="customerIPAddress">Optional IP address of the customer used for tracing their actions</param>
+        /// <param name="customName">Optional custom name for account</param>
+        /// <param name="accountType">Optional type for account (Defaults to a managed account)</param>
+        /// <returns></returns>
+        Task<SignableResponse> CreateAccountOnStellarAsync(string customerCode, string publicKey, IEnumerable<TokenCodeWithData> tokensWithData, string? customerIPAddress = null, string? customName = null, string? accountType = "MANAGED");
 
         /// <summary>
         ///
@@ -76,6 +101,18 @@ namespace Nexus.Sdk.Token
         Task<SignableResponse> CreateAccountOnAlgorandAsync(string customerCode, string publicKey, IEnumerable<string> tokenCodes, string? customerIPAddress = null, string? customName = null, string? accountType = "MANAGED");
 
         /// <summary>
+        /// Create a new account on the Algorand blockchain, connecting it with tokens and optional per-token metadata
+        /// </summary>
+        /// <param name="customerCode"></param>
+        /// <param name="publicKey"></param>
+        /// <param name="tokensWithData">Token codes with optional metadata</param>
+        /// <param name="customerIPAddress">Optional IP address of the customer used for tracing their actions</param>
+        /// <param name="customName">Optional custom name for account</param>
+        /// <param name="accountType">Optional type for account (Defaults to a managed account)</param>
+        /// <returns></returns>
+        Task<SignableResponse> CreateAccountOnAlgorandAsync(string customerCode, string publicKey, IEnumerable<TokenCodeWithData> tokensWithData, string? customerIPAddress = null, string? customName = null, string? accountType = "MANAGED");
+
+        /// <summary>
         ///
         /// </summary>
         /// <param name="accountCode"></param>
@@ -99,6 +136,15 @@ namespace Nexus.Sdk.Token
         /// <param name="customerIPAddress">Optional IP address of the customer used for tracing their actions</param>
         /// <returns></returns>
         Task<SignableResponse> ConnectAccountToTokensAsync(string accountCode, IEnumerable<string> tokenCodes, string? customerIPAddress = null);
+
+        /// <summary>
+        /// Connect tokens with optional per-token metadata to an account
+        /// </summary>
+        /// <param name="accountCode"></param>
+        /// <param name="tokensWithData">Token codes with optional metadata</param>
+        /// <param name="customerIPAddress">Optional IP address of the customer used for tracing their actions</param>
+        /// <returns></returns>
+        Task<SignableResponse> ConnectAccountToTokensAsync(string accountCode, IEnumerable<TokenCodeWithData> tokensWithData, string? customerIPAddress = null);
 
         /// <summary>
         /// Updates account properties based on the code

--- a/Nexus.Sdk.Token/Requests/AccountRequests.cs
+++ b/Nexus.Sdk.Token/Requests/AccountRequests.cs
@@ -53,10 +53,19 @@ public class UpdateTokenAccountSettings
     public AllowedTokens? AllowedTokens { get; set; }
 }
 
+public class TokenCodeWithData
+{
+    [JsonPropertyName("tokenCode")]
+    public required string TokenCode { get; set; }
+
+    [JsonPropertyName("data")]
+    public IDictionary<string, string>? Data { get; set; }
+}
+
 public class AllowedTokens
 {
     [JsonPropertyName("addTokens")]
-    public IEnumerable<string>? AddTokens { get; set; }
+    public IEnumerable<TokenCodeWithData>? AddTokens { get; set; }
 
     [JsonPropertyName("removeTokens")]
     public string[]? RemoveTokens { get; set; }
@@ -71,5 +80,5 @@ public class AllowedTokens
 public class CreateTokenAccountSettings
 {
     [JsonPropertyName("allowedTokens")]
-    public IEnumerable<string>? AllowedTokens { get; set; }
+    public IEnumerable<TokenCodeWithData>? AllowedTokens { get; set; }
 }

--- a/Nexus.Sdk.Token/Responses/AccountResponses.cs
+++ b/Nexus.Sdk.Token/Responses/AccountResponses.cs
@@ -61,10 +61,11 @@ public record TokenSettingsResponse
 public record AllowedTokensResponse
 {
     [JsonConstructor]
-    public AllowedTokensResponse(string tokenCode, string status)
+    public AllowedTokensResponse(string tokenCode, string status, IDictionary<string, string>? data = null)
     {
         TokenCode = tokenCode;
         Status = status;
+        Data = data;
     }
 
     [JsonPropertyName("tokenCode")]
@@ -72,6 +73,9 @@ public record AllowedTokensResponse
 
     [JsonPropertyName("status")]
     public string Status { get; set; }
+
+    [JsonPropertyName("data")]
+    public IDictionary<string, string>? Data { get; set; }
 }
 
 public record UpdateTokenAccountResponse

--- a/Nexus.Sdk.Token/Responses/AccountResponses.cs
+++ b/Nexus.Sdk.Token/Responses/AccountResponses.cs
@@ -126,3 +126,27 @@ public record AccountBalance
     public AccountBalance(string tokenCode, decimal amount, bool enabled)
         => (TokenCode, Amount, Enabled) = (tokenCode, amount, enabled);
 }
+
+public record AccountTokenResponse
+{
+    [JsonConstructor]
+    public AccountTokenResponse(string accountCode, string tokenCode, string status, IDictionary<string, string>? data = null)
+    {
+        AccountCode = accountCode;
+        TokenCode = tokenCode;
+        Status = status;
+        Data = data;
+    }
+
+    [JsonPropertyName("accountCode")]
+    public string AccountCode { get; set; }
+
+    [JsonPropertyName("tokenCode")]
+    public string TokenCode { get; set; }
+
+    [JsonPropertyName("status")]
+    public string Status { get; set; }
+
+    [JsonPropertyName("data")]
+    public IDictionary<string, string>? Data { get; set; }
+}

--- a/Nexus.Sdk.Token/Responses/TokenResponses.cs
+++ b/Nexus.Sdk.Token/Responses/TokenResponses.cs
@@ -63,10 +63,10 @@ public class PeggedByResponse
     public string Code { get; }
     
     [JsonPropertyName("rate")]
-    public decimal Rate { get; }
+    public decimal? Rate { get; }
 
     [JsonConstructor]
-    public PeggedByResponse(string type, string code, decimal rate)
+    public PeggedByResponse(string type, string code, decimal? rate)
     {
         Type = type;
         Code = code;
@@ -77,10 +77,10 @@ public class PeggedByResponse
 public class TokenDetailSettingsResponse
 {
     [JsonPropertyName("accountLimit")]
-    public decimal AccountLimit { get; }
+    public decimal? AccountLimit { get; }
 
     [JsonPropertyName("overallLimit")]
-    public decimal OverallLimit { get; }
+    public decimal? OverallLimit { get; }
     
     [JsonPropertyName("returnable")]
     public bool Returnable { get; }
@@ -92,7 +92,7 @@ public class TokenDetailSettingsResponse
     public int Decimals { get; }
 
     [JsonConstructor]
-    public TokenDetailSettingsResponse(decimal accountLimit, decimal overallLimit, bool returnable, bool freezeAfterFund, int decimals)
+    public TokenDetailSettingsResponse(decimal? accountLimit, decimal? overallLimit, bool returnable, bool freezeAfterFund, int decimals)
     {
         AccountLimit = accountLimit;
         OverallLimit = overallLimit;

--- a/Nexus.Sdk.Token/TokenServerProvider.cs
+++ b/Nexus.Sdk.Token/TokenServerProvider.cs
@@ -52,6 +52,13 @@ namespace Nexus.Sdk.Token
         /// <returns></returns>
         public async Task<SignableResponse> ConnectAccountToTokensAsync(string accountCode, IEnumerable<string> tokenCodes, string? customerIPAddress = null)
         {
+            return await ConnectAccountToTokensAsync(accountCode,
+                tokenCodes.Select(tc => new TokenCodeWithData { TokenCode = tc }),
+                customerIPAddress);
+        }
+
+        public async Task<SignableResponse> ConnectAccountToTokensAsync(string accountCode, IEnumerable<TokenCodeWithData> tokensWithData, string? customerIPAddress = null)
+        {
             var builder = new RequestBuilder(_client, _handler, logger, _headers)
                 .SetSegments("accounts", accountCode)
                 .AddHeader("customer_ip_address", customerIPAddress);
@@ -62,7 +69,7 @@ namespace Nexus.Sdk.Token
                 {
                     AllowedTokens = new AllowedTokens
                     {
-                        AddTokens = tokenCodes
+                        AddTokens = tokensWithData
                     }
                 }
             };
@@ -88,7 +95,38 @@ namespace Nexus.Sdk.Token
                 CryptoCode = cryptoCode,
                 TokenSettings = new CreateTokenAccountSettings
                 {
-                    AllowedTokens = allowedTokens
+                    AllowedTokens = allowedTokens.Select(tc => new TokenCodeWithData { TokenCode = tc })
+                }
+            };
+
+            if (!string.IsNullOrWhiteSpace(customName))
+            {
+                request.CustomName = customName;
+            }
+
+            return await builder.ExecutePost<CreateVirtualAccountRequest, AccountResponse>(request);
+        }
+
+        public async Task<AccountResponse> CreateVirtualAccount(string customerCode, string address, bool generateReceiveAddress, string cryptoCode, IEnumerable<TokenCodeWithData> tokensWithData, string? customerIPAddress = null, string? customName = null)
+        {
+            if (!string.IsNullOrWhiteSpace(address) && generateReceiveAddress)
+            {
+                throw new InvalidOperationException("Supplying an address and requesting one to be generated is unsupported.");
+            }
+
+            var builder = new RequestBuilder(_client, _handler, logger, _headers)
+                .SetSegments("customer", customerCode, "accounts")
+                .AddHeader("customer_ip_address", customerIPAddress);
+
+            var request = new CreateVirtualAccountRequest
+            {
+                GenerateReceiveAddress = generateReceiveAddress,
+                Address = address,
+                AccountType = "VIRTUAL",
+                CryptoCode = cryptoCode,
+                TokenSettings = new CreateTokenAccountSettings
+                {
+                    AllowedTokens = tokensWithData
                 }
             };
 
@@ -131,6 +169,13 @@ namespace Nexus.Sdk.Token
 
         public async Task<SignableResponse> CreateAccountOnAlgorandAsync(string customerCode, string publicKey, IEnumerable<string> allowedTokens, string? customerIPAddress = null, string? customName = null, string? accountType = "MANAGED")
         {
+            return await CreateAccountOnAlgorandAsync(customerCode, publicKey,
+                allowedTokens.Select(tc => new TokenCodeWithData { TokenCode = tc }),
+                customerIPAddress, customName, accountType);
+        }
+
+        public async Task<SignableResponse> CreateAccountOnAlgorandAsync(string customerCode, string publicKey, IEnumerable<TokenCodeWithData> tokensWithData, string? customerIPAddress = null, string? customName = null, string? accountType = "MANAGED")
+        {
             var builder = new RequestBuilder(_client, _handler, logger, _headers)
                 .SetSegments("customer", customerCode, "accounts")
                 .AddHeader("customer_ip_address", customerIPAddress);
@@ -141,7 +186,7 @@ namespace Nexus.Sdk.Token
                 AccountType = accountType,
                 TokenSettings = new CreateTokenAccountSettings
                 {
-                    AllowedTokens = allowedTokens
+                    AllowedTokens = tokensWithData
                 }
             };
 
@@ -182,6 +227,13 @@ namespace Nexus.Sdk.Token
 
         public async Task<SignableResponse> CreateAccountOnStellarAsync(string customerCode, string publicKey, IEnumerable<string> allowedTokens, string? customerIPAddress = null, string? customName = null, string? accountType = "MANAGED")
         {
+            return await CreateAccountOnStellarAsync(customerCode, publicKey,
+                allowedTokens.Select(tc => new TokenCodeWithData { TokenCode = tc }),
+                customerIPAddress, customName, accountType);
+        }
+
+        public async Task<SignableResponse> CreateAccountOnStellarAsync(string customerCode, string publicKey, IEnumerable<TokenCodeWithData> tokensWithData, string? customerIPAddress = null, string? customName = null, string? accountType = "MANAGED")
+        {
             var builder = new RequestBuilder(_client, _handler, logger, _headers)
                 .SetSegments("customer", customerCode, "accounts")
                 .AddHeader("customer_ip_address", customerIPAddress);
@@ -192,7 +244,7 @@ namespace Nexus.Sdk.Token
                 AccountType = accountType,
                 TokenSettings = new CreateTokenAccountSettings
                 {
-                    AllowedTokens = allowedTokens
+                    AllowedTokens = tokensWithData
                 }
             };
 

--- a/Nexus.Sdk.Token/TokenServerProvider.cs
+++ b/Nexus.Sdk.Token/TokenServerProvider.cs
@@ -657,6 +657,24 @@ namespace Nexus.Sdk.Token
         }
 
         /// <summary>
+        /// Lists account tokens based on the query parameters.
+        /// </summary>
+        /// <param name="queryParameters">Query parameters to filter on (accountCode, tokenCode, page, limit, data_* filters).</param>
+        /// <returns>A paged list of account tokens matching the search criteria.</returns>
+        public async Task<PagedResponse<AccountTokenResponse>> GetAccountTokensAsync(IDictionary<string, string>? queryParameters)
+        {
+            var builder = new RequestBuilder(_client, _handler, logger, _headers)
+                .SetSegments("accounts", "tokens");
+
+            if (queryParameters != null)
+            {
+                builder.SetQueryParameters(queryParameters);
+            }
+
+            return await builder.ExecuteGet<PagedResponse<AccountTokenResponse>>();
+        }
+
+        /// <summary>
         ///
         /// </summary>
         /// <param name="customerCode"></param>

--- a/Nexus.Token.Algorand.Examples/AlgorandExamples.cs
+++ b/Nexus.Token.Algorand.Examples/AlgorandExamples.cs
@@ -172,6 +172,47 @@ namespace Nexus.Token.Algorand.Examples
             _ = _tokenServer.Submit.OnAlgorandAsync(signedResponse);
         }
 
+        public async Task CreateAccountWithTokenDataAsync(string customerCode, string tokenCode, IDictionary<string, string> data)
+        {
+            var request = new CreateCustomerRequestBuilder(customerCode, "Trusted", "EUR").Build();
+            var customer = await _tokenServer.Customers.Create(request);
+
+            var kp = AlgorandKeyPair.Generate();
+
+            _logger.LogWarning("Generated new Algorand account for {customerCode}: {accountCode}", customer.CustomerCode, kp.GetAccountCode());
+
+            var tokensWithData = new[] { new TokenCodeWithData { TokenCode = tokenCode, Data = data } };
+            var signableResponse = await _tokenServer.Accounts.CreateOnAlgorandAsync(customer.CustomerCode, kp.GetPublicKey(), tokensWithData);
+            var signedResponse = kp.Sign(signableResponse, true);
+            await _tokenServer.Submit.OnAlgorandAsync(signedResponse);
+
+            _logger.LogWarning("Account created and connected to {tokenCode} with metadata", tokenCode);
+
+            var account = await _tokenServer.Accounts.Get(kp.GetAccountCode());
+            foreach (var token in account.TokenSettings?.AllowedTokens ?? [])
+            {
+                _logger.LogWarning("Token {tokenCode} status={status} data={data}", token.TokenCode, token.Status, token.Data);
+            }
+        }
+
+        public async Task ConnectTokenWithDataAsync(string encryptedPrivateKey, string tokenCode, IDictionary<string, string> data)
+        {
+            var kp = AlgorandKeyPair.FromPrivateKey(encryptedPrivateKey, _decrypter);
+
+            var tokensWithData = new[] { new TokenCodeWithData { TokenCode = tokenCode, Data = data } };
+            var signableResponse = await _tokenServer.Accounts.ConnectToTokensAsync(kp.GetAccountCode(), tokensWithData);
+            var signedResponse = kp.Sign(signableResponse, true);
+            await _tokenServer.Submit.OnAlgorandAsync(signedResponse);
+
+            _logger.LogWarning("Connected token {tokenCode} with metadata to account {accountCode}", tokenCode, kp.GetAccountCode());
+
+            var account = await _tokenServer.Accounts.Get(kp.GetAccountCode());
+            foreach (var token in account.TokenSettings?.AllowedTokens ?? [])
+            {
+                _logger.LogWarning("Token {tokenCode} status={status} data={data}", token.TokenCode, token.Status, token.Data);
+            }
+        }
+
         public async Task PaymentAsync(string encryptedSenderPrivateKey, string encryptedReceiverPrivateKey, string tokenCode, decimal amount)
         {
             var sender = AlgorandKeyPair.FromPrivateKey(encryptedSenderPrivateKey, _decrypter);

--- a/Nexus.Token.Algorand.Examples/AlgorandExamples.cs
+++ b/Nexus.Token.Algorand.Examples/AlgorandExamples.cs
@@ -172,7 +172,7 @@ namespace Nexus.Token.Algorand.Examples
             _ = _tokenServer.Submit.OnAlgorandAsync(signedResponse);
         }
 
-        public async Task CreateAccountWithTokenDataAsync(string customerCode, string tokenCode, IDictionary<string, string> data)
+        public async Task<string> CreateAccountWithTokenDataAsync(string customerCode, string tokenCode, IDictionary<string, string> data)
         {
             var request = new CreateCustomerRequestBuilder(customerCode, "Trusted", "EUR").Build();
             var customer = await _tokenServer.Customers.Create(request);
@@ -193,6 +193,8 @@ namespace Nexus.Token.Algorand.Examples
             {
                 _logger.LogWarning("Token {tokenCode} status={status} data={data}", token.TokenCode, token.Status, token.Data);
             }
+
+            return kp.GetPrivateKey(_encrypter);
         }
 
         public async Task ConnectTokenWithDataAsync(string encryptedPrivateKey, string tokenCode, IDictionary<string, string> data)

--- a/Nexus.Token.Algorand.Examples/AlgorandExamples.cs
+++ b/Nexus.Token.Algorand.Examples/AlgorandExamples.cs
@@ -213,6 +213,16 @@ namespace Nexus.Token.Algorand.Examples
             {
                 _logger.LogWarning("Token {tokenCode} status={status} data={data}", token.TokenCode, token.Status, token.Data);
             }
+
+            // Query account tokens by data property filter
+            _logger.LogWarning("Querying account tokens by data property filters");
+            var accountTokensResult = await _tokenServer.Accounts.GetAccountTokensAsync(dataFilters: data);
+            _logger.LogWarning("Found {total} account token(s) matching data filters:", accountTokensResult.Total);
+            foreach (var accountToken in accountTokensResult.Records)
+            {
+                _logger.LogWarning("  AccountCode={accountCode} TokenCode={tokenCode} Status={status} Data={tokenData}",
+                    accountToken.AccountCode, accountToken.TokenCode, accountToken.Status, accountToken.Data);
+            }
         }
 
         public async Task PaymentAsync(string encryptedSenderPrivateKey, string encryptedReceiverPrivateKey, string tokenCode, decimal amount)

--- a/Nexus.Token.Algorand.Examples/Program.cs
+++ b/Nexus.Token.Algorand.Examples/Program.cs
@@ -55,6 +55,9 @@ namespace Nexus.Token.Algorand.Examples
                         case 5:
                             await AlgorandUpdateTokenOperationStatusFlow(algorandExample);
                             break;
+                        case 6:
+                            await AlgorandTokenDataFlow(algorandExample);
+                            break;
                         default:
                             WriteToConsole("Flow not supported");
                             break;
@@ -250,6 +253,26 @@ namespace Nexus.Token.Algorand.Examples
             {
                 WriteToConsole("Payment code is null or empty, cannot update operation status.", ConsoleColor.Red);
             }
+        }
+
+        public static async Task AlgorandTokenDataFlow(AlgorandExamples algorandExamples)
+        {
+            WriteToConsole("Create a new token representing the Mona Lisa");
+            var tokenCode = Guid.NewGuid().ToString()[..8];
+            await algorandExamples.CreateAssetTokenAsync(tokenCode, "Mona Lisa");
+
+            WriteToConsole("Create a new token representing the Nachtwacht");
+            var tokenCode2 = Guid.NewGuid().ToString()[..8];
+            await algorandExamples.CreateAssetTokenAsync(tokenCode2, "Nachtwacht");
+
+            WriteToConsole("Create an account for Bob, connecting him to the Mona Lisa token with an IBAN number");
+            var bob = Guid.NewGuid().ToString();
+            var data = new Dictionary<string, string> { { "VIBANNUMBER", "NL67INGB8855988913" } };
+            var bobsPrivateKey = await algorandExamples.CreateAccountWithTokenDataAsync(bob, tokenCode, data);
+
+            WriteToConsole("Now connect Bob to the Nachtwacht token with a different IBAN");
+            var data2 = new Dictionary<string, string> { { "VIBANNUMBER", "NL67INGB8855988914" } };
+            await algorandExamples.ConnectTokenWithDataAsync(bobsPrivateKey, tokenCode2, data2);
         }
 
         private static void WriteToConsole(string message, ConsoleColor textColor = ConsoleColor.Green)

--- a/Nexus.Token.Algorand.Examples/Program.cs
+++ b/Nexus.Token.Algorand.Examples/Program.cs
@@ -23,7 +23,7 @@ namespace Nexus.Token.Algorand.Examples
                 WriteToConsole("3 = Algorand Multiple Operations Flow");
                 WriteToConsole("4 = Algorand Token Limits Flow");
                 WriteToConsole("5 = Algorand Update Token Operation Status Flow");
-                WriteToConsole("6 = Algorand Token Data Flow");
+                WriteToConsole("6 = Algorand Account Token Data Flow");
 
                 Console.Write("Please type in a number: ");
                 var command = Console.ReadLine();

--- a/Nexus.Token.Algorand.Examples/Program.cs
+++ b/Nexus.Token.Algorand.Examples/Program.cs
@@ -23,6 +23,7 @@ namespace Nexus.Token.Algorand.Examples
                 WriteToConsole("3 = Algorand Multiple Operations Flow");
                 WriteToConsole("4 = Algorand Token Limits Flow");
                 WriteToConsole("5 = Algorand Update Token Operation Status Flow");
+                WriteToConsole("6 = Algorand Token Data Flow");
 
                 Console.Write("Please type in a number: ");
                 var command = Console.ReadLine();

--- a/Nexus.Token.Stellar.Examples/Program.cs
+++ b/Nexus.Token.Stellar.Examples/Program.cs
@@ -66,6 +66,9 @@ namespace Nexus.Token.Stellar.Examples
                         case 7:
                             await StellarUpdateTokenOperationStatusFlow(stellarExamples);
                             break;
+                        case 8:
+                            await StellarTokenDataFlow(stellarExamples);
+                            break;
                         default:
                             WriteToConsole("Flow not supported");
                             break;
@@ -336,6 +339,26 @@ namespace Nexus.Token.Stellar.Examples
             {
                 WriteToConsole("Payment code is null or empty, cannot update operation status.", ConsoleColor.Red);
             }
+        }
+
+        public static async Task StellarTokenDataFlow(StellarExamples stellarExamples)
+        {
+            WriteToConsole("Create a new token representing the Mona Lisa");
+            var tokenCode = Guid.NewGuid().ToString()[..8];
+            await stellarExamples.CreateAssetTokenAsync(tokenCode, "Mona Lisa");
+
+            WriteToConsole("Create a new token representing the Nachtwacht");
+            var tokenCode2 = Guid.NewGuid().ToString()[..8];
+            await stellarExamples.CreateAssetTokenAsync(tokenCode2, "Nachtwacht");
+
+            WriteToConsole("Create an account for Bob, connecting him to the Mona Lisa token with an IBAN number");
+            var bob = Guid.NewGuid().ToString();
+            var data = new Dictionary<string, string> { { "VIBANNUMBER", "NL67INGB8855988913" } };
+            var bobsPrivateKey = await stellarExamples.CreateAccountWithTokenDataAsync(bob, tokenCode, data);
+
+            WriteToConsole("Now connect Bob to the Nachtwacht token with a different IBAN");
+            var data2 = new Dictionary<string, string> { { "VIBANNUMBER", "NL67INGB8855988914" } };
+            await stellarExamples.ConnectTokenWithDataAsync(bobsPrivateKey, tokenCode2, data2);
         }
 
         private static void WriteToConsole(string message, ConsoleColor textColor = ConsoleColor.Green)

--- a/Nexus.Token.Stellar.Examples/Program.cs
+++ b/Nexus.Token.Stellar.Examples/Program.cs
@@ -28,6 +28,7 @@ namespace Nexus.Token.Stellar.Examples
                 WriteToConsole("5 = Stellar Multiple Operations Flow");
                 WriteToConsole("6 = Stellar Token Limits Flow");
                 WriteToConsole("7 = Stellar Update Token Operation Status Flow");
+                WriteToConsole("8 = Stellar Token Data Flow");
 
                 Console.Write("Please type in a number: ");
                 var command = Console.ReadLine();

--- a/Nexus.Token.Stellar.Examples/Program.cs
+++ b/Nexus.Token.Stellar.Examples/Program.cs
@@ -28,7 +28,7 @@ namespace Nexus.Token.Stellar.Examples
                 WriteToConsole("5 = Stellar Multiple Operations Flow");
                 WriteToConsole("6 = Stellar Token Limits Flow");
                 WriteToConsole("7 = Stellar Update Token Operation Status Flow");
-                WriteToConsole("8 = Stellar Token Data Flow");
+                WriteToConsole("8 = Stellar Account Token Data Flow");
 
                 Console.Write("Please type in a number: ");
                 var command = Console.ReadLine();

--- a/Nexus.Token.Stellar.Examples/StellarExamples.cs
+++ b/Nexus.Token.Stellar.Examples/StellarExamples.cs
@@ -222,6 +222,16 @@ namespace Nexus.Token.Stellar.Examples
             {
                 _logger.LogWarning("Token {tokenCode} status={status} data={data}", token.TokenCode, token.Status, token.Data);
             }
+
+            // Query account tokens by data property filter
+            _logger.LogWarning("Querying account tokens by data property filters");
+            var accountTokensResult = await _tokenServer.Accounts.GetAccountTokensAsync(dataFilters: data);
+            _logger.LogWarning("Found {total} account token(s) matching data filters:", accountTokensResult.Total);
+            foreach (var accountToken in accountTokensResult.Records)
+            {
+                _logger.LogWarning("  AccountCode={accountCode} TokenCode={tokenCode} Status={status} Data={tokenData}",
+                    accountToken.AccountCode, accountToken.TokenCode, accountToken.Status, accountToken.Data);
+            }
         }
 
         public async Task PaymentAsync(string encryptedSenderPrivateKey, string encryptedReceiverPrivateKey, string tokenCode, decimal amount)

--- a/Nexus.Token.Stellar.Examples/StellarExamples.cs
+++ b/Nexus.Token.Stellar.Examples/StellarExamples.cs
@@ -181,6 +181,47 @@ namespace Nexus.Token.Stellar.Examples
             await _tokenServer.Submit.OnStellarAsync(signedResponse);
         }
 
+        public async Task CreateAccountWithTokenDataAsync(string customerCode, string tokenCode, IDictionary<string, string> data)
+        {
+            var request = new CreateCustomerRequestBuilder(customerCode, "Trusted", "EUR").Build();
+            var customer = await _tokenServer.Customers.Create(request);
+
+            var kp = StellarKeyPair.Generate();
+
+            _logger.LogWarning("Generated new Stellar account for {customerCode}: {accountCode}", customer.CustomerCode, kp.GetAccountCode());
+
+            var tokensWithData = new[] { new TokenCodeWithData { TokenCode = tokenCode, Data = data } };
+            var signableResponse = await _tokenServer.Accounts.CreateOnStellarAsync(customer.CustomerCode, kp.GetPublicKey(), tokensWithData);
+            var signedResponse = kp.Sign(signableResponse, _network);
+            await _tokenServer.Submit.OnStellarAsync(signedResponse);
+
+            _logger.LogWarning("Account created and connected to {tokenCode} with metadata", tokenCode);
+
+            var account = await _tokenServer.Accounts.Get(kp.GetAccountCode());
+            foreach (var token in account.TokenSettings?.AllowedTokens ?? [])
+            {
+                _logger.LogWarning("Token {tokenCode} status={status} data={data}", token.TokenCode, token.Status, token.Data);
+            }
+        }
+
+        public async Task ConnectTokenWithDataAsync(string encryptedPrivateKey, string tokenCode, IDictionary<string, string> data)
+        {
+            var kp = StellarKeyPair.FromPrivateKey(encryptedPrivateKey, _decrypter);
+
+            var tokensWithData = new[] { new TokenCodeWithData { TokenCode = tokenCode, Data = data } };
+            var signableResponse = await _tokenServer.Accounts.ConnectToTokensAsync(kp.GetAccountCode(), tokensWithData);
+            var signedResponse = kp.Sign(signableResponse, _network);
+            await _tokenServer.Submit.OnStellarAsync(signedResponse);
+
+            _logger.LogWarning("Connected token {tokenCode} with metadata to account {accountCode}", tokenCode, kp.GetAccountCode());
+
+            var account = await _tokenServer.Accounts.Get(kp.GetAccountCode());
+            foreach (var token in account.TokenSettings?.AllowedTokens ?? [])
+            {
+                _logger.LogWarning("Token {tokenCode} status={status} data={data}", token.TokenCode, token.Status, token.Data);
+            }
+        }
+
         public async Task PaymentAsync(string encryptedSenderPrivateKey, string encryptedReceiverPrivateKey, string tokenCode, decimal amount)
         {
             var sender = StellarKeyPair.FromPrivateKey(encryptedSenderPrivateKey, _decrypter);

--- a/Nexus.Token.Stellar.Examples/StellarExamples.cs
+++ b/Nexus.Token.Stellar.Examples/StellarExamples.cs
@@ -181,7 +181,7 @@ namespace Nexus.Token.Stellar.Examples
             await _tokenServer.Submit.OnStellarAsync(signedResponse);
         }
 
-        public async Task CreateAccountWithTokenDataAsync(string customerCode, string tokenCode, IDictionary<string, string> data)
+        public async Task<string> CreateAccountWithTokenDataAsync(string customerCode, string tokenCode, IDictionary<string, string> data)
         {
             var request = new CreateCustomerRequestBuilder(customerCode, "Trusted", "EUR").Build();
             var customer = await _tokenServer.Customers.Create(request);
@@ -202,6 +202,8 @@ namespace Nexus.Token.Stellar.Examples
             {
                 _logger.LogWarning("Token {tokenCode} status={status} data={data}", token.TokenCode, token.Status, token.Data);
             }
+
+            return kp.GetPrivateKey(_encrypter);
         }
 
         public async Task ConnectTokenWithDataAsync(string encryptedPrivateKey, string tokenCode, IDictionary<string, string> data)

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "8.0.418",
+    "rollForward": "latestFeature",
+    "allowPrerelease": false
+  }
+}


### PR DESCRIPTION
The ability to associate `EntityData` with `AccountToken` records was recently introduced into the Nexus API and Portal in order to support Virtual IBAN data. This pull request extends support for these changes to the SDK. It introduces new overloads to key methods in the accounts facade and provider interfaces, allowing the creation of accounts and connecting tokens with associated metadata. Additionally, it adds a new method for retrieving paginated account tokens,.

**API and Interface Enhancements:**
* Added overloads to `IAccountsFacade` and `ITokenServerProvider` interfaces for creating accounts (virtual, Stellar, Algorand) and connecting tokens, now accepting `IEnumerable<TokenCodeWithData>` to support per-token metadata. 
* Introduced a new method in `IAccountsFacade` and `ITokenServerProvider` to get a paginated list of account tokens, with support for filtering by account code, token code, and data properties.

**Facade Implementation Updates:**

* Implemented the new overloads in `AccountsFacade`, forwarding calls to the provider for account creation and token connection with metadata. 
* Added logic in `AccountsFacade` to construct query parameters for the new paginated account tokens method, including support for data property filters.

**Testing:**
- The Stellar and Algorand example flows were extended to demonstrate the use of the overloaded and new method introduced in this pull request.

**Other:**
- Added `global.json` file to project
- Updated `TokenResponse` in order to fix some broken sample flows in the Algorand and Stellar examples