### PR TITLE
NXS-7674: Update SDK with Trust Level changes

### DIFF
--- a/Nexus.Sdk.Shared/Responses/TrustLevelsResponse.cs
+++ b/Nexus.Sdk.Shared/Responses/TrustLevelsResponse.cs
@@ -5,14 +5,17 @@ namespace Nexus.Sdk.Shared.Responses
     public record TrustLevelsResponse
     {
         [JsonConstructor]
-        public TrustLevelsResponse(string name, string? description, bool isActive, Limits? buyLimits, Limits? sellLimits, OverallLimits? overallLimits)
+        public TrustLevelsResponse(string name, string? description, bool isActive, bool requireExecutedSellDoesNotExceedLifetimeBuy, decimal? monthlyExemptionAmount, Limits? buyLimits, Limits? sellLimits, OverallLimits? overallLimits, Dictionary<string, bool> flags)
         {
             Name = name;
             Description = description;
             IsActive = isActive;
+            RequireExecutedSellDoesNotExceedLifetimeBuy = requireExecutedSellDoesNotExceedLifetimeBuy;
+            MonthlyExemptionAmount = monthlyExemptionAmount;
             BuyLimits = buyLimits;
             SellLimits = sellLimits;
             OverallLimits = overallLimits;
+            Flags = flags;
         }
 
         [JsonPropertyName("name")]
@@ -24,6 +27,12 @@ namespace Nexus.Sdk.Shared.Responses
         [JsonPropertyName("isActive")]
         public bool IsActive { get; set; }
 
+        [JsonPropertyName("requireExecutedSellDoesNotExceedLifetimeBuy")]
+        public bool RequireExecutedSellDoesNotExceedLifetimeBuy { get; set; }
+
+        [JsonPropertyName("monthlyExemptionAmount")]
+        public decimal? MonthlyExemptionAmount { get; set; }
+
         [JsonPropertyName("buyLimits")]
         public Limits? BuyLimits { get; set; }
 
@@ -32,6 +41,9 @@ namespace Nexus.Sdk.Shared.Responses
 
         [JsonPropertyName("overallLimits")]
         public OverallLimits? OverallLimits { get; set; }
+
+        [JsonPropertyName("flags")]
+        public Dictionary<string, bool> Flags { get; set; }
     }
 
     public class Limits
@@ -60,14 +72,10 @@ namespace Nexus.Sdk.Shared.Responses
 
     public class OverallLimits
     {
-        public OverallLimits(double? custodianLimit, decimal? tokenBalanceLimit)
+        public OverallLimits(decimal? tokenBalanceLimit)
         {
-            CustodianLimit = custodianLimit;
             TokenBalanceLimit = tokenBalanceLimit;
         }
-
-        [JsonPropertyName("custodianLimit")]
-        public double? CustodianLimit { get; set; }
 
         [JsonPropertyName("tokenBalanceLimit")]
         public decimal? TokenBalanceLimit { get; set; }

--- a/Nexus.Sdk.Token.Tests/Helpers/MockTokenServerProvider.cs
+++ b/Nexus.Sdk.Token.Tests/Helpers/MockTokenServerProvider.cs
@@ -305,7 +305,7 @@ namespace Nexus.Sdk.Token.Tests.Helpers
             throw new NotImplementedException();
         }
 
-        public Task<TokenLimitsResponse> GetTokenPayoutLimits(string customerCode, string tokenCode, string? blockchainCode = null)
+        public Task<TokenPayoutLimitsResponse> GetTokenPayoutLimits(string customerCode, string tokenCode, string? blockchainCode = null)
         {
             throw new NotImplementedException();
         }

--- a/Nexus.Sdk.Token/Facades/Interfaces/ITokenLimitsFacade.cs
+++ b/Nexus.Sdk.Token/Facades/Interfaces/ITokenLimitsFacade.cs
@@ -24,6 +24,6 @@ namespace Nexus.Sdk.Token.Facades
         /// <returns>
         /// The current fiat spending limits expressed in token value.
         /// </returns>
-        public Task<TokenLimitsResponse> GetPayoutLimits(string customerCode, string tokenCode, string? blockchainCode = null);
+        public Task<TokenPayoutLimitsResponse> GetPayoutLimits(string customerCode, string tokenCode, string? blockchainCode = null);
     }
 }

--- a/Nexus.Sdk.Token/Facades/TokenLimitsFacade.cs
+++ b/Nexus.Sdk.Token/Facades/TokenLimitsFacade.cs
@@ -13,7 +13,7 @@ namespace Nexus.Sdk.Token.Facades
             return await _provider.GetTokenFundingLimits(customerCode, tokenCode, blockchainCode);
         }
 
-        public async Task<TokenLimitsResponse> GetPayoutLimits(string customerCode, string tokenCode, string? blockchainCode = null)
+        public async Task<TokenPayoutLimitsResponse> GetPayoutLimits(string customerCode, string tokenCode, string? blockchainCode = null)
         {
             return await _provider.GetTokenPayoutLimits(customerCode, tokenCode, blockchainCode);
         }

--- a/Nexus.Sdk.Token/ITokenServerProvider.cs
+++ b/Nexus.Sdk.Token/ITokenServerProvider.cs
@@ -412,7 +412,7 @@ namespace Nexus.Sdk.Token
         /// <returns>
         /// The current fiat spending limits expressed in token value.
         /// </returns>
-        Task<TokenLimitsResponse> GetTokenPayoutLimits(string customerCode, string tokenCode, string? blockchainCode = null);
+        Task<TokenPayoutLimitsResponse> GetTokenPayoutLimits(string customerCode, string tokenCode, string? blockchainCode = null);
 
         /// <summary>
         /// Get payment method data

--- a/Nexus.Sdk.Token/Responses/TokenLimitsResponse.cs
+++ b/Nexus.Sdk.Token/Responses/TokenLimitsResponse.cs
@@ -30,6 +30,23 @@ public record TokenLimitsResponse
     public TrustlevelLimit Total { get;  set; }
 }
 
+public record TokenPayoutLimitsResponse : TokenLimitsResponse
+{
+    [JsonConstructor]
+    public TokenPayoutLimitsResponse(string tokenCode, decimal limit, string[] limitReasons, TrustlevelLimit remaining, TrustlevelLimit total, bool requireExecutedSellDoesNotExceedLifetimeBuy, decimal? monthlyExemptionAmount)
+        : base(tokenCode, limit, limitReasons, remaining, total)
+    {
+        RequireExecutedSellDoesNotExceedLifetimeBuy = requireExecutedSellDoesNotExceedLifetimeBuy;
+        MonthlyExemptionAmount = monthlyExemptionAmount;
+    }
+
+    [JsonPropertyName("requireExecutedSellDoesNotExceedLifetimeBuy")]
+    public bool RequireExecutedSellDoesNotExceedLifetimeBuy { get; set; }
+
+    [JsonPropertyName("monthlyExemptionAmount")]
+    public decimal? MonthlyExemptionAmount { get; set; }
+}
+
 public record TrustlevelLimit
 {
     [JsonConstructor]

--- a/Nexus.Sdk.Token/TokenServerProvider.cs
+++ b/Nexus.Sdk.Token/TokenServerProvider.cs
@@ -985,7 +985,7 @@ namespace Nexus.Sdk.Token
             return await builder.ExecuteGet<TokenLimitsResponse>();
         }
 
-        public async Task<TokenLimitsResponse> GetTokenPayoutLimits(string customerCode, string tokenCode, string? blockchainCode = null)
+        public async Task<TokenPayoutLimitsResponse> GetTokenPayoutLimits(string customerCode, string tokenCode, string? blockchainCode = null)
         {
             var builder = new RequestBuilder(_client, _handler, logger, _headers);
             if (!string.IsNullOrWhiteSpace(blockchainCode))
@@ -996,7 +996,7 @@ namespace Nexus.Sdk.Token
             {
                 builder.SetSegments("customer", customerCode, "limits", "tokenpayout", "token", tokenCode);
             }
-            return await builder.ExecuteGet<TokenLimitsResponse>();
+            return await builder.ExecuteGet<TokenPayoutLimitsResponse>();
         }
 
         public async Task<PagedResponse<TrustLevelsResponse>> GetTrustLevels(IDictionary<string, string>? queryParameters)

--- a/Nexus.Token.Algorand.Examples/AlgorandExamples.cs
+++ b/Nexus.Token.Algorand.Examples/AlgorandExamples.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using Nexus.Sdk.Shared.Requests;
+using Nexus.Sdk.Shared.Responses;
 using Nexus.Sdk.Token;
 using Nexus.Sdk.Token.KeyPairs;
 using Nexus.Sdk.Token.Requests;
@@ -287,7 +288,7 @@ namespace Nexus.Token.Algorand.Examples
             return fundingLimitsResponse;
         }
 
-        public async Task<TokenLimitsResponse> GetTokenPayoutLimits(string customerCode, string tokenCode)
+        public async Task<TokenPayoutLimitsResponse> GetTokenPayoutLimits(string customerCode, string tokenCode)
         {
             var payoutLimitsResponse = await _tokenServer.TokenLimits.GetPayoutLimits(customerCode, tokenCode, "ALGO");
 

--- a/Nexus.Token.Stellar.Examples/StellarExamples.cs
+++ b/Nexus.Token.Stellar.Examples/StellarExamples.cs
@@ -390,7 +390,7 @@ namespace Nexus.Token.Stellar.Examples
             return fundingLimitsResponse;
         }
 
-        public async Task<TokenLimitsResponse> GetTokenPayoutLimits(string customerCode, string tokenCode)
+        public async Task<TokenPayoutLimitsResponse> GetTokenPayoutLimits(string customerCode, string tokenCode)
         {
             var payoutLimitsResponse = await _tokenServer.TokenLimits.GetPayoutLimits(customerCode, tokenCode, "XLM");
 


### PR DESCRIPTION
This pull request introduces new properties to the trust level and token payout limits response models, and updates the relevant interfaces and implementations to support these changes. 

**Trust Level and Limits Model Enhancements:**
- Added `requireExecutedSellDoesNotExceedLifetimeBuy`, `monthlyExemptionAmount`, and a `flags` dictionary to the `TrustLevelsResponse` model,
- Removed the `custodianLimit` property from the `OverallLimits` class.

**Token Payout Limits Response Expansion:**
- Introduced a new `TokenPayoutLimitsResponse` record, inheriting from `TokenLimitsResponse`, which includes the new `requireExecutedSellDoesNotExceedLifetimeBuy` and `monthlyExemptionAmount` properties for payout-specific limit responses.
- Updated method signatures in interfaces and implementations (`ITokenLimitsFacade`, `ITokenServerProvider`, facade classes, and example projects) to return the new `TokenPayoutLimitsResponse` instead of the generic `TokenLimitsResponse` for payout-related methods. This ensures consumers can access the extended properties. 